### PR TITLE
Add docker npm scripts, update docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,12 @@ x-common-service-settings: &common_service_settings
     XAUTHORITY: "${XAUTHORITY:-}"
     XDG_SESSION_TYPE: "${XDG_SESSION_TYPE:-}"
     NVIDIA_DRIVER_CAPABILITIES: "all"
-
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - capabilities:
+            - gpu
 services:
 
   runtime:

--- a/docs/docker/installation.md
+++ b/docs/docker/installation.md
@@ -42,21 +42,21 @@ sudo systemctl restart docker
 
 ## Installing docker-compose
 
-Follow the [official docker-compose installation instructions](https://docs.docker.com/compose/install/) to install docker-compose for your OS.
+Follow the [official docker-compose installation instructions](https://docs.docker.com/compose/install/) to install docker-compose v1.28.5+ for your OS.
 <details>
 <summary>Click here to see Ubuntu 16.04+ docker-compose installation commands:</summary>
 <pre>
-# Install docker-compose v1.26.2, or select any release in https://github.com/docker/compose/releases
-DOCKER_COMPOSE_VERSION=1.26.2<br/>
+# Install docker-compose v1.28.5, or select any newer release in https://github.com/docker/compose/releases
+DOCKER_COMPOSE_VERSION=1.28.5<br/>
 sudo curl \
     -L https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` \
     -o /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose
 </pre>
 </details>
 
-## Using the nvidia-container-runtime with docker-compose
+## Using the nvidia-container-runtime with docker-compose before v1.28.5
 
-At the time of writing, using the nvidia-container-runtime with docker-compose [requires](https://github.com/docker/compose/issues/6691) `nvidia-container-runtime` is set as the default docker runtime. To do this, you will need to create or edit the `/etc/docker/daemon.json` file and update the "default-runtime" and "runtimes" settings.
+Prior to docker-compose v1.28.5, using the nvidia-container-runtime with docker-compose [requires](https://github.com/docker/compose/issues/6691) `nvidia-container-runtime` is set as the default docker runtime. To do this, you will need to create or edit the `/etc/docker/daemon.json` file and update the "default-runtime" and "runtimes" settings.
 <details>
 <summary>Click here to see an example daemon.json:</summary>
 <pre>

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,10 +26,10 @@ To build and run the development container, issue the following commands:
 
 ```bash
 # Build the development container
-docker-compose build devel
+yarn docker:build:devel
 
 # Start the development container
-docker-compose run --rm devel
+yarn docker:run:devel
 ```
 
 Now execute the following commands inside this running container:
@@ -44,7 +44,7 @@ You can also build and run on a properly configured Linux installation without d
 
 ### Dependencies
 
-We assume you have [node, npm](https://github.com/nvm-sh/nvm#installing-and-updating), [yarn](https://yarnpkg.com/getting-started/install), and [CMake](https://cmake.org/) installed.
+We assume you have [node, npm](https://github.com/nvm-sh/nvm#installing-and-updating), [yarn](https://yarnpkg.com/getting-started/install), [CMake v3.18.5+](https://cmake.org/), and [CUDA Toolkit 11.0+](https://developer.nvidia.com/cuda-downloads) installed.
 
 <details>
 <summary>Click here to see Ubuntu 16.04+ CMake installation commands:</summary>
@@ -65,7 +65,7 @@ To install the rest of the dependencies necessary for building the native C++ an
 # Installs VSCode, C++ intellisense plugins, and system libraries.
 # Checks whether individual components are already installed,
 # and asks permission before installing new components.
-npm run dev:install-cpp-dependencies
+yarn dev:install-cpp-dependencies
 ```
 
 ## Setup yarn workspaces
@@ -83,11 +83,11 @@ To build the C++ and Typescript, issue any of the following commands:
 
 ```bash
 # Run CMake configure, find native dependencies, and compile C++/TypeScript
-npm run build
+yarn build
 # Perform a fast recompile (without the CMake configure step):
-npm run compile
+yarn compile
 # Perform a clean reconfigure/rebuild:
-npm run rebuild
+yarn rebuild
 ```
 
 ### C++-only builds
@@ -95,9 +95,9 @@ npm run rebuild
 Issue the above commands with the `cpp:` prefix to only build the C++ modules. The `:debug` suffix will run each command with `CMAKE_BUILD_TYPE=Debug`.
 
 ```bash
-npm run cpp:build # or cpp:build:debug
-npm run cpp:compile # or cpp:compile:debug
-npm run cpp:rebuild # or cpp:rebuild:debug
+yarn cpp:build # or cpp:build:debug
+yarn cpp:compile # or cpp:compile:debug
+yarn cpp:rebuild # or cpp:rebuild:debug
 ```
 
 These npm scripts are also available in each module. Running them from each module's directory will output GCC colors.
@@ -107,7 +107,7 @@ These npm scripts are also available in each module. Running them from each modu
 You can run a demo to test the build by issuing the command:
 
 ```bash
-npm run demo modules/demo/luma 01
+yarn demo modules/demo/luma 01
 ```
 
 ## Troubleshooting
@@ -132,7 +132,7 @@ Some rememedies for potential error messages you may encounter.
   
   source ~/.bashrc
   ```
-  
- * > ninja: error: loading 'build.ninja': No such file or directory
 
-   Need to execure `npm run build -- --clean` from the top, or `npm run rebuild` from inside the module 
+* > ninja: error: loading 'build.ninja': No such file or directory
+
+  Need to execure `yarn rebuild` from the top from inside the module

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "clean": "scripts/exec.js clean",
-    "doc": "rimraf doc && typedoc --options typedoc.js && npm run doc:packages",
+    "doc": "rimraf doc && typedoc --options typedoc.js && yarn doc:packages",
     "doc:packages": "scripts/exec.js run doc",
     "demo": "scripts/exec.js demo",
     "test": "scripts/exec.js test",
@@ -23,12 +23,17 @@
     "cpp:build:debug": "scripts/exec.js run cpp:build:debug",
     "cpp:compile:debug": "scripts/exec.js run cpp:compile:debug",
     "cpp:rebuild:debug": "scripts/exec.js run cpp:rebuild:debug",
+    "docker:build:devel": "touch .env && docker-compose build devel",
+    "docker:build:runtime": "touch .env && docker-compose build runtime",
+    "docker:build:nteract": "touch .env && docker-compose build nteract",
+    "docker:run:devel": "touch .env && docker-compose run --rm devel",
+    "docker:run:runtime": "touch .env && docker-compose run --rm runtime",
+    "docker:run:nteract": "touch .env && docker-compose run --rm nteract",
     "tsc:build": "scripts/exec.js run tsc:build",
     "tsc:watch": "scripts/exec.js run tsc:watch --parallel",
     "dev:relink-bin-dirs": "scripts/exec.js relink-bin-dirs",
     "dev:install-cpp-dependencies": "modules/core/bin/exec_install_deps.js",
     "nuke:from:orbit": "yarn cache clean && yarn clean && yarn --silent && yarn rebuild",
-    "preinstall": "touch .env",
     "postinstall": "yarn dev:relink-bin-dirs"
   },
   "workspaces": [

--- a/scripts/demo/linux.sh
+++ b/scripts/demo/linux.sh
@@ -46,7 +46,7 @@ if [[ "$DEMO" == "" ]]; then
         fi
     done;
     echo "Run this demo directly via:"
-    echo "\`npm run demo $DEMO${@:+ ${@:-}}\`"
+    echo "\`yarn demo $DEMO${@:+ ${@:-}}\`"
 fi
 
 ARGS="${@:-}";


### PR DESCRIPTION
* Adds scripts to build/run the containers, and update the docs with the new commands:
  ```
  yarn docker:build:devel
  yarn docker:run:devel
  ```
  In addition to being simpler than invoking `docker-compose` directly, these commands will also `touch .env` beforehand, to ensure the `.env` file is created before docker-compose attempts to read it.

* Deletes the current `.env` file, which should hopefully go back to being gitignored locally.
* Adds the new configuration options to `docker-compose.yml` which should allow docker-compose v1.28.5+ to use the `"nvidia"` runtime without needing to set `"default-runtime": "nvidia"` in `/etc/docker/daemon.json`. Instructions on how to modify this file for older versions of docker-compose have been left in place.

Branched from https://github.com/rapidsai/node-rapids/pull/114, so we should merge it first.