### PR TITLE
Add GH action for docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,47 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/typedoc.js'
+      - '**/tsconfig.json'
+      - '**/package.json'
+      - 'modules/**'
+      - '.github/workflows/**'
+      - '!**/tests/**'
+
+jobs:
+  update:
+    name: Update Docs
+    runs-on: ubuntu-20.04
+    container: node:14
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+        with:
+          path: main
+      - name: Checkout gh-pages
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Build Docs
+        working-directory: main
+        run: yarn && yarn tsc:build && yarn doc
+      - name: Copy Docs to gh-pages
+        run: |
+          rm -rf gh-pages/docs
+          cp -r main/doc gh-pages/docs
+      - name: Commit new docs
+        working-directory: gh-pages
+        run: |
+          COMMIT_SHA=$(echo "${COMMIT_SHA}" | cut -c 1-7)
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add --all
+          git commit --allow-empty -m "update docs from ${COMMIT_SHA}"
+          git push gh-pages
+        env:
+          COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,11 +6,8 @@ on:
       - main
     paths:
       - '**/typedoc.js'
-      - '**/tsconfig.json'
-      - '**/package.json'
-      - 'modules/**'
+      - 'modules/**/src/**/*.ts'
       - '.github/workflows/**'
-      - '!**/tests/**'
 
 jobs:
   update:


### PR DESCRIPTION
This PR adds a GitHub Action for automatically updating the `gh-pages` branch with the latest docs.

It works by checking out both the `main` and `gh-pages` branches to separate directories, doing a doc build in the `main` directory, copying the results to the `gh-pages` directory, then finally committing/pushing the changes to the `gh-pages` branch.

I added the `paths` key to try to eliminate excessive builds from irrelevant file changes, but this can be tweaked/removed if necessary (file matching patterns are [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#patterns-to-match-file-paths))