### PR TITLE
Add regex series functions

### DIFF
--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -216,6 +216,10 @@ Napi::Object Column::Init(Napi::Env env, Napi::Object exports) {
                   InstanceMethod<&Column::rint>("rint"),
                   InstanceMethod<&Column::bit_invert>("bit_invert"),
                   InstanceMethod<&Column::unary_not>("not"),
+                  // column/re.cpp
+                  InstanceMethod<&Column::contains_re>("containsRe"),
+                  InstanceMethod<&Column::count_re>("countRe"),
+                  InstanceMethod<&Column::matches_re>("matchesRe"),
                 });
 
   Column::constructor = Napi::Persistent(ctor);

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -22,6 +22,7 @@ import {
   DataType,
   Float64,
   IndexType,
+  Int32,
   Int64,
   Integral,
   Numeric,
@@ -30,7 +31,8 @@ import {CommonType, Interpolation} from './types/mappings';
 
 export type ColumnProps<T extends DataType = any> = {
   /*
-   * ColumnProps *with* a `nullMask` shouldn't allow `data` to be an Array with elements and nulls:
+   * ColumnProps *with* a `nullMask` shouldn't allow `data` to be an Array with elements and
+   * nulls:
    * ```javascript
    * new Column({
    *   type: new Int32,
@@ -48,7 +50,8 @@ export type ColumnProps<T extends DataType = any> = {
   children?: ReadonlyArray<Column>| null;
 }|{
   /*
-   * ColumnProps *without* a `nullMask` should allow `data` to be an Array with elements and nulls:
+   * ColumnProps *without* a `nullMask` should allow `data` to be an Array with elements and
+   * nulls:
    * ```javascript
    * new Column({
    *   type: new Int32,
@@ -534,6 +537,41 @@ export interface Column<T extends DataType = any> {
    * @returns Column of same size as `input` containing result of the cast operation.
    */
   cast<R extends DataType>(dataType: R, memoryResource?: MemoryResource): Column<R>;
+
+  /**
+   * Creates a column of `BOOL8` elements where `true` indicates the value is null and `false`
+   * indicates the row matches the given pattern
+   *
+   * @param pattern Regex pattern to match to each string.
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   * @returns A non-nullable column of `BOOL8` elements with `true` representing `null`
+   *   values.
+   */
+  containsRe(pattern: string, memoryResource?: MemoryResource): Column<Bool8>;
+
+  /**
+   * Creates a column of `INT32` elements where `true` indicates the number of times the given
+   * regex pattern matches in each string.
+   *
+   * @param pattern Regex pattern to match to each string.
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   * @returns A non-nullable column of `INT32` counts
+   */
+  countRe(pattern: string, memoryResource?: MemoryResource): Column<Int32>;
+
+  /**
+   * Creates a column of `BOOL8` elements where `true` indicates the value is null and `false`
+   * indicates the row matches the given pattern only at the beginning of the string
+   *
+   * @param pattern Regex pattern to match to each string.
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   * @returns A non-nullable column of `BOOL8` elements with `true` representing `null`
+   *   values.
+   */
+  matchesRe(pattern: string, memoryResource?: MemoryResource): Column<Bool8>;
 
   /**
    * Creates a column of `BOOL8` elements where `true` indicates the value is null and `false`

--- a/modules/cudf/src/column/re.cpp
+++ b/modules/cudf/src/column/re.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <node_cudf/column.hpp>
+#include <node_cudf/utilities/napi_to_cpp.hpp>
+
+#include <node_rmm/memory_resource.hpp>
+
+#include <cudf/unary.hpp>
+
+#include <rmm/mr/device/per_device_resource.hpp>
+#include "cudf/strings/contains.hpp"
+
+namespace nv {
+
+ObjectUnwrap<Column> Column::contains_re(std::string const& pattern,
+                                         rmm::mr::device_memory_resource* mr) const {
+  try {
+    return Column::New(cudf::strings::contains_re(this->view(), pattern, mr));
+  } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(Env(), err.what())); }
+}
+
+ObjectUnwrap<Column> Column::count_re(std::string const& pattern,
+                                      rmm::mr::device_memory_resource* mr) const {
+  try {
+    return Column::New(cudf::strings::count_re(this->view(), pattern, mr));
+  } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(Env(), err.what())); }
+}
+
+ObjectUnwrap<Column> Column::matches_re(std::string const& pattern,
+                                        rmm::mr::device_memory_resource* mr) const {
+  try {
+    return Column::New(cudf::strings::matches_re(this->view(), pattern, mr));
+  } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(Env(), err.what())); }
+}
+
+Napi::Value Column::contains_re(Napi::CallbackInfo const& info) {
+  if (info.Length() < 1) {
+    NODE_CUDF_THROW("Column contains_re expects a pattern and optional MemoryResource", info.Env());
+  }
+  return contains_re(NapiToCPP{info[0]},
+                     NapiToCPP(info[1]).operator rmm::mr::device_memory_resource*());
+}
+
+Napi::Value Column::count_re(Napi::CallbackInfo const& info) {
+  if (info.Length() < 1) {
+    NODE_CUDF_THROW("Column contains_re expects a pattern and optional MemoryResource", info.Env());
+  }
+  return count_re(NapiToCPP{info[0]},
+                  NapiToCPP(info[1]).operator rmm::mr::device_memory_resource*());
+}
+
+Napi::Value Column::matches_re(Napi::CallbackInfo const& info) {
+  if (info.Length() < 1) {
+    NODE_CUDF_THROW("Column contains_re expects a pattern and optional MemoryResource", info.Env());
+  }
+  return matches_re(NapiToCPP{info[0]},
+                    NapiToCPP(info[1]).operator rmm::mr::device_memory_resource*());
+}
+
+}  // namespace nv

--- a/modules/cudf/src/column/re.cpp
+++ b/modules/cudf/src/column/re.cpp
@@ -20,7 +20,7 @@
 #include <cudf/unary.hpp>
 
 #include <rmm/mr/device/per_device_resource.hpp>
-#include "cudf/strings/contains.hpp"
+#include <cudf/strings/contains.hpp>
 
 namespace nv {
 

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -627,6 +627,21 @@ class Column : public Napi::ObjectWrap<Column> {
     cudf::unary_operator op,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
+  // column/re.cpp
+  ObjectUnwrap<Column> contains_re(
+    std::string const& pattern,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  ObjectUnwrap<Column> count_re(
+    std::string const& pattern,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  // TODO: findall_re
+
+  ObjectUnwrap<Column> matches_re(
+    std::string const& pattern,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
  private:
   static Napi::FunctionReference constructor;
 
@@ -745,6 +760,12 @@ class Column : public Napi::ObjectWrap<Column> {
   Napi::Value rint(Napi::CallbackInfo const& info);
   Napi::Value bit_invert(Napi::CallbackInfo const& info);
   Napi::Value unary_not(Napi::CallbackInfo const& info);
+
+  // column/re.cpp
+  Napi::Value contains_re(Napi::CallbackInfo const& info);
+  Napi::Value count_re(Napi::CallbackInfo const& info);
+  // Napi::Value findall_re(Napi::CallbackInfo const& info);
+  Napi::Value matches_re(Napi::CallbackInfo const& info);
 };
 
 }  // namespace nv

--- a/modules/cudf/src/series/string.ts
+++ b/modules/cudf/src/series/string.ts
@@ -16,7 +16,7 @@ import {MemoryResource} from '@rapidsai/rmm';
 import * as arrow from 'apache-arrow';
 
 import {Series} from '../series';
-import {DataType, Int32, Uint8, Utf8String} from '../types/dtypes';
+import {Bool8, DataType, Int32, Uint8, Utf8String} from '../types/dtypes';
 
 /**
  * A Series of utf8-string values in GPU memory.
@@ -45,4 +45,39 @@ export class StringSeries extends Series<Utf8String> {
    */
   // TODO: Account for this.offset
   get data() { return Series.new(this._col.getChild<Uint8>(1)); }
+
+  /**
+   * Returns a boolean series identifying rows which match the given regex pattern.
+   *
+   * @param pattern Regex pattern to match to each string.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   */
+  containsRe(pattern: string, memoryResource?: MemoryResource): Series<Bool8> {
+    return Series.new(this._col.containsRe(pattern, memoryResource));
+  }
+
+  /**
+   * Returns an Int32 series the number of times the given regex pattern matches
+   * in each string.
+   *
+   * @param pattern Regex pattern to match to each string.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   */
+  countRe(pattern: string, memoryResource?: MemoryResource): Series<Int32> {
+    return Series.new(this._col.countRe(pattern, memoryResource));
+  }
+
+  /**
+   * Returns a boolean series identifying rows which match the given regex pattern
+   * only at the beginning of the string
+   *
+   * @param pattern Regex pattern to match to each string.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   */
+  matchesRe(pattern: string, memoryResource?: MemoryResource): Series<Bool8> {
+    return Series.new(this._col.matchesRe(pattern, memoryResource));
+  }
 }

--- a/modules/cudf/src/series/string.ts
+++ b/modules/cudf/src/series/string.ts
@@ -52,9 +52,16 @@ export class StringSeries extends Series<Utf8String> {
    * @param pattern Regex pattern to match to each string.
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
+   *
+   * The regex pattern strings accepted are described here:
+   *
+   * https://docs.rapids.ai/api/libcudf/stable/md_regex.html
+   *
+   * A RegExp may also be passed, however all flags are ignored (only `pattern.source` is used)
    */
-  containsRe(pattern: string, memoryResource?: MemoryResource): Series<Bool8> {
-    return Series.new(this._col.containsRe(pattern, memoryResource));
+  containsRe(pattern: string|RegExp, memoryResource?: MemoryResource): Series<Bool8> {
+    const pat_string = pattern instanceof RegExp ? pattern.source : pattern;
+    return Series.new(this._col.containsRe(pat_string, memoryResource));
   }
 
   /**
@@ -64,9 +71,16 @@ export class StringSeries extends Series<Utf8String> {
    * @param pattern Regex pattern to match to each string.
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
+   *
+   * The regex pattern strings accepted are described here:
+   *
+   * https://docs.rapids.ai/api/libcudf/stable/md_regex.html
+   *
+   * A RegExp may also be passed, however all flags are ignored (only `pattern.source` is used)
    */
-  countRe(pattern: string, memoryResource?: MemoryResource): Series<Int32> {
-    return Series.new(this._col.countRe(pattern, memoryResource));
+  countRe(pattern: string|RegExp, memoryResource?: MemoryResource): Series<Int32> {
+    const pat_string = pattern instanceof RegExp ? pattern.source : pattern;
+    return Series.new(this._col.countRe(pat_string, memoryResource));
   }
 
   /**
@@ -76,8 +90,15 @@ export class StringSeries extends Series<Utf8String> {
    * @param pattern Regex pattern to match to each string.
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
+   *
+   * The regex pattern strings accepted are described here:
+   *
+   * https://docs.rapids.ai/api/libcudf/stable/md_regex.html
+   *
+   * A RegExp may also be passed, however all flags are ignored (only `pattern.source` is used)
    */
-  matchesRe(pattern: string, memoryResource?: MemoryResource): Series<Bool8> {
-    return Series.new(this._col.matchesRe(pattern, memoryResource));
+  matchesRe(pattern: string|RegExp, memoryResource?: MemoryResource): Series<Bool8> {
+    const pat_string = pattern instanceof RegExp ? pattern.source : pattern;
+    return Series.new(this._col.matchesRe(pat_string, memoryResource));
   }
 }

--- a/modules/cudf/test/series/string-tests.ts
+++ b/modules/cudf/test/series/string-tests.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION.
+// Copyright (c) 2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,18 +37,18 @@ describe.each([['foo'], [/foo/], [/foo/ig]])('Series regex search (pattern=%p)',
   test('containsRe', () => {
     const expected = [true, true, true, true, true, false, false, true, true];
     const s        = StringSeries.new(Utf8Vector.from(data));
-    expect([...s.containsRe(pattern).toArrow()]).toEqual(expected);
+    expect([...s.containsRe(pattern)]).toEqual(expected);
   });
 
   test('countRe', () => {
     const expected = [1, 1, 1, 2, 1, 0, 0, 1, 1];
     const s        = StringSeries.new(Utf8Vector.from(data));
-    expect([...s.countRe(pattern).toArrow()]).toEqual(expected);
+    expect([...s.countRe(pattern)]).toEqual(expected);
   });
 
   test('matchesRe', () => {
     const expected = [true, false, false, true, false, false, false, false, false];
     const s        = StringSeries.new(Utf8Vector.from(data));
-    expect([...s.matchesRe(pattern).toArrow()]).toEqual(expected);
+    expect([...s.matchesRe(pattern)]).toEqual(expected);
   });
 });

--- a/modules/cudf/test/series/string-tests.ts
+++ b/modules/cudf/test/series/string-tests.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2020, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {setDefaultAllocator} from '@nvidia/cuda';
+import {StringSeries} from '@rapidsai/cudf';
+import {CudaMemoryResource, DeviceBuffer} from '@rapidsai/rmm';
+import {Utf8Vector} from 'apache-arrow';
+
+const mr = new CudaMemoryResource();
+
+setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength, mr));
+
+const data = [
+  'foo bar baz',   // start of string
+  ' foo bar baz',  // start of string after whitespace
+  'baz bar foo',   // end of string
+  'foo bar foo',   // start and end
+  'bar foo baz',   // middle
+  'baz quux',      // missing
+  'FoO',           // wrong case
+  'bar\n foo',     // multi-line
+  'bar\nfoo'       // multi-line
+];
+
+describe.each([['foo'], [/foo/], [/foo/ig]])('Series regex search (pattern=%p)', (pattern) => {
+  test('containsRe', () => {
+    const expected = [true, true, true, true, true, false, false, true, true];
+    const s        = StringSeries.new(Utf8Vector.from(data));
+    expect([...s.containsRe(pattern).toArrow()]).toEqual(expected);
+  });
+
+  test('countRe', () => {
+    const expected = [1, 1, 1, 2, 1, 0, 0, 1, 1];
+    const s        = StringSeries.new(Utf8Vector.from(data));
+    expect([...s.countRe(pattern).toArrow()]).toEqual(expected);
+  });
+
+  test('matchesRe', () => {
+    const expected = [true, false, false, true, false, false, false, false, false];
+    const s        = StringSeries.new(Utf8Vector.from(data));
+    expect([...s.matchesRe(pattern).toArrow()]).toEqual(expected);
+  });
+});


### PR DESCRIPTION
issues: closes #120 

```node
> a = Arrow.Utf8Vector.from(["foo bar baz", "baz bar foo", "foo bar foo", "baz quux"])

> s = cudf.StringSeries.new(a)
StringSeries { _col: Column {} }
> [...s.containsRe("foo").toArrow()]
[ true, true, true, false ]
> [...s.countRe("foo").toArrow()]
[ 1, 1, 2, 0 ]
> [...s.matchesRe("foo").toArrow()]
[ true, false, true, false ]
```

Still needs tests and `findall_re` (or a separate issue) 