### PR TITLE
Fix GitHub Action for Docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,7 +13,7 @@ jobs:
   update:
     name: Update Docs
     runs-on: ubuntu-20.04
-    container: node:14
+    container: node:14-buster
     steps:
       - name: Checkout main
         uses: actions/checkout@v2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,6 +39,6 @@ jobs:
           git config user.email "actions@github.com"
           git add --all
           git commit --allow-empty -m "update docs from ${COMMIT_SHA}"
-          git push gh-pages
+          git push
         env:
           COMMIT_SHA: ${{ github.sha }}


### PR DESCRIPTION
This PR fixes the GitHub Action added in #119. The screenshot below shows the `git` related error messages that occurred when the docs tried to deploy. The `git` version was older than is supported by the `actions/checkout` stage, and therefore the repo was cloned using GitHub's API instead of `git`. As a result, the doc changes could not be committed in the final stage of the pipeline. This PR updates the `node` image to an image with a newer version of `git`. It also updates the `git push` command. The correct syntax should've been `github push origin gh-pages`, but the last two parameters are optional anyway.

![image](https://user-images.githubusercontent.com/7400326/111336900-038ada00-864c-11eb-8835-66771da9cbcb.png)
