### PR TITLE
Add scatter for Series

### DIFF
--- a/modules/cudf/src/node_cudf/table.hpp
+++ b/modules/cudf/src/node_cudf/table.hpp
@@ -172,10 +172,23 @@ class Table : public Napi::ObjectWrap<Table> {
     cudf::size_type threshold,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
+  // table/copying.cpp
   ObjectUnwrap<Table> gather(
     Column const& gather_map,
     cudf::out_of_bounds_policy bounds_policy = cudf::out_of_bounds_policy::DONT_CHECK,
     rmm::mr::device_memory_resource* mr      = rmm::mr::get_current_device_resource()) const;
+
+  ObjectUnwrap<Table> scatter_scalar(
+    std::vector<std::reference_wrapper<const cudf::scalar>> const& source,
+    Column const& indices,
+    bool check_bounds                   = false,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  ObjectUnwrap<Table> scatter_table(
+    Table const& source,
+    Column const& indices,
+    bool check_bounds                   = false,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
  private:
   static Napi::FunctionReference constructor;
@@ -187,10 +200,13 @@ class Table : public Napi::ObjectWrap<Table> {
   Napi::Value num_columns(Napi::CallbackInfo const& info);
   Napi::Value num_rows(Napi::CallbackInfo const& info);
   Napi::Value select(Napi::CallbackInfo const& info);
-  Napi::Value gather(Napi::CallbackInfo const& info);
   Napi::Value get_column(Napi::CallbackInfo const& info);
   Napi::Value drop_nulls(Napi::CallbackInfo const& info);
   Napi::Value drop_nans(Napi::CallbackInfo const& info);
+  // table/copying.cpp
+  Napi::Value gather(Napi::CallbackInfo const& info);
+  Napi::Value scatter_scalar(Napi::CallbackInfo const& info);
+  Napi::Value scatter_table(Napi::CallbackInfo const& info);
 
   static Napi::Value read_csv(Napi::CallbackInfo const& info);
   Napi::Value write_csv(Napi::CallbackInfo const& info);

--- a/modules/cudf/src/node_cudf/table.hpp
+++ b/modules/cudf/src/node_cudf/table.hpp
@@ -178,13 +178,13 @@ class Table : public Napi::ObjectWrap<Table> {
     cudf::out_of_bounds_policy bounds_policy = cudf::out_of_bounds_policy::DONT_CHECK,
     rmm::mr::device_memory_resource* mr      = rmm::mr::get_current_device_resource()) const;
 
-  ObjectUnwrap<Table> scatter_scalar(
+  ObjectUnwrap<Table> scatter(
     std::vector<std::reference_wrapper<const cudf::scalar>> const& source,
     Column const& indices,
     bool check_bounds                   = false,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
-  ObjectUnwrap<Table> scatter_table(
+  ObjectUnwrap<Table> scatter(
     Table const& source,
     Column const& indices,
     bool check_bounds                   = false,

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -226,7 +226,7 @@ export class AbstractSeries<T extends DataType = any> {
 
   scatter(source: Series<T>|T['scalarType'],
           indices: Series<Int32>|number[],
-          check_bounds?: boolean,
+          check_bounds = false,
           memoryResource?: MemoryResource): void {
     const dst  = new Table({columns: [this._col]});
     const inds = indices instanceof Series ? indices : new Series({type: new Int32, data: indices});

--- a/modules/cudf/src/table.cpp
+++ b/modules/cudf/src/table.cpp
@@ -37,6 +37,8 @@ Napi::Object Table::Init(Napi::Env env, Napi::Object exports) {
                                     {
                                       InstanceAccessor<&Table::num_columns>("numColumns"),
                                       InstanceAccessor<&Table::num_rows>("numRows"),
+                                      InstanceMethod<&Table::scatter_scalar>("scatterScalar"),
+                                      InstanceMethod<&Table::scatter_table>("scatterTable"),
                                       InstanceMethod<&Table::gather>("gather"),
                                       InstanceMethod<&Table::get_column>("getColumnByIndex"),
                                       InstanceMethod<&Table::to_arrow>("toArrow"),
@@ -136,18 +138,6 @@ Napi::Value Table::num_columns(Napi::CallbackInfo const& info) {
 }
 
 Napi::Value Table::num_rows(Napi::CallbackInfo const& info) { return CPPToNapi(info)(num_rows()); }
-
-Napi::Value Table::gather(Napi::CallbackInfo const& info) {
-  CallbackArgs args{info};
-  if (!Column::is_instance(args[0])) {
-    throw Napi::Error::New(info.Env(), "gather selection argument expects a Column");
-  }
-  auto& selection = *Column::Unwrap(args[0]);
-  if (selection.type().id() == cudf::type_id::BOOL8) {
-    return this->apply_boolean_mask(selection)->Value();
-  }
-  return this->gather(selection)->Value();
-}
 
 Napi::Value Table::get_column(Napi::CallbackInfo const& info) {
   cudf::size_type i = CallbackArgs{info}[0];

--- a/modules/cudf/src/table.ts
+++ b/modules/cudf/src/table.ts
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {MemoryResource} from '@rapidsai/rmm';
 import CUDF from './addon';
 import {Column} from './column';
+import {Scalar} from './scalar';
 import {CSVTypeMap, ReadCSVOptions, WriteCSVOptions} from './types/csv';
-import {
-  Bool8,
-  DataType,
-  IndexType,
-  Int32,
-} from './types/dtypes';
-import {
-  NullOrder,
-} from './types/enums';
+import {Bool8, DataType, IndexType, Int32} from './types/dtypes';
+import {NullOrder} from './types/enums';
+import {TypeMap} from './types/mappings';
 
 export type ToArrowMetadata = [string | number, ToArrowMetadata[]?];
 
@@ -70,6 +66,36 @@ export interface Table {
    * @param selection
    */
   gather(selection: Column<IndexType|Bool8>): Table;
+
+  /**
+   * Scatters row of values into this Table according to provided indices.
+   *
+   * @param source A column of values to be scattered in to this Series
+   * @param indices A column of integral indices that indicate the rows in the this Series to be
+   *   replaced by `value`.
+   * @param check_bounds Optionally perform bounds checking on the indices and throw an error if any
+   *   of its values are out of bounds (default: false).
+   * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
+   */
+  scatterScalar<T extends TypeMap = any>(source: (Scalar<T[keyof T]>)[],
+                                         indices: Column<Int32>,
+                                         check_bounds?: boolean,
+                                         memoryResource?: MemoryResource): Table;
+
+  /**
+   * Scatters a Table of values into this Table according to provided indices.
+   *
+   * @param value A value to be scattered in to this Series
+   * @param indices A column of integral indices that indicate the rows in the this Series to be
+   *   replaced by `value`.
+   * @param check_bounds Optionally perform bounds checking on the indices and throw an error if any
+   *   of its values are out of bounds (default: false).
+   * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
+   */
+  scatterTable(source: Table,
+               indices: Column<Int32>,
+               check_bounds?: boolean,
+               memoryResource?: MemoryResource): Table;
 
   /**
    * Get the Column at a specified index

--- a/modules/cudf/src/table/copying.cpp
+++ b/modules/cudf/src/table/copying.cpp
@@ -87,9 +87,9 @@ Napi::Value Table::scatter_scalar(Napi::CallbackInfo const& info) {
   if (!Column::is_instance(args[1])) {
     throw Napi::Error::New(info.Env(), "scatter_scalar indices argument expects a Column");
   }
-  auto& indices     = *Column::Unwrap(args[1]);
-  auto check_bounds = args[2];
-  auto* mr          = NapiToCPP(info[3]).operator rmm::mr::device_memory_resource*();
+  auto& indices                       = *Column::Unwrap(args[1]);
+  bool check_bounds                   = args[2];
+  rmm::mr::device_memory_resource* mr = args[3];
   return scatter(source, indices, check_bounds, mr)->Value();
 }
 
@@ -112,8 +112,8 @@ Napi::Value Table::scatter_table(Napi::CallbackInfo const& info) {
   }
   auto& indices = *Column::Unwrap(args[1]);
 
-  auto check_bounds = args[2];
-  auto* mr          = NapiToCPP(info[3]).operator rmm::mr::device_memory_resource*();
+  bool check_bounds                   = args[2];
+  rmm::mr::device_memory_resource* mr = args[3];
   return scatter(source, indices, check_bounds, mr)->Value();
 }
 

--- a/modules/cudf/src/table/copying.cpp
+++ b/modules/cudf/src/table/copying.cpp
@@ -14,6 +14,7 @@
 
 #include <node_cudf/column.hpp>
 #include <node_cudf/table.hpp>
+#include <node_cudf/utilities/napi_to_cpp.hpp>
 
 #include <cudf/copying.hpp>
 #include <cudf/table/table_view.hpp>
@@ -26,6 +27,109 @@ ObjectUnwrap<Table> Table::gather(Column const& gather_map,
                                   cudf::out_of_bounds_policy bounds_policy,
                                   rmm::mr::device_memory_resource* mr) const {
   return Table::New(cudf::gather(cudf::table_view{{*this}}, gather_map, bounds_policy, mr));
+}
+
+ObjectUnwrap<Table> Table::scatter_scalar(
+  std::vector<std::reference_wrapper<const cudf::scalar>> const& source,
+  Column const& indices,
+  bool check_bounds,
+  rmm::mr::device_memory_resource* mr) const {
+  try {
+    return Table::New(cudf::scatter(source, indices.view(), this->view(), check_bounds, mr));
+  } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(Env(), err.what())); }
+}
+
+ObjectUnwrap<Table> Table::scatter_table(Table const& source,
+                                         Column const& indices,
+                                         bool check_bounds,
+                                         rmm::mr::device_memory_resource* mr) const {
+  try {
+    return Table::New(cudf::scatter(source.view(), indices.view(), this->view(), check_bounds, mr));
+  } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(Env(), err.what())); }
+}
+
+Napi::Value Table::gather(Napi::CallbackInfo const& info) {
+  CallbackArgs args{info};
+  if (!Column::is_instance(args[0])) {
+    throw Napi::Error::New(info.Env(), "gather selection argument expects a Column");
+  }
+  auto& selection = *Column::Unwrap(args[0]);
+  if (selection.type().id() == cudf::type_id::BOOL8) {
+    return this->apply_boolean_mask(selection)->Value();
+  }
+  return this->gather(selection)->Value();
+}
+
+Napi::Value Table::scatter_scalar(Napi::CallbackInfo const& info) {
+  CallbackArgs args{info};
+  if (!args[0].IsArray()) {
+    throw Napi::Error::New(info.Env(), "scatter_scalar source argument expects an array");
+  }
+  auto const source_array = args[0].As<Napi::Array>();
+  std::vector<std::reference_wrapper<const cudf::scalar>> source{};
+
+  for (uint32_t i = 0; i < source_array.Length(); ++i) {
+    if (!Scalar::is_instance(source_array.Get(i))) {
+      throw Napi::Error::New(info.Env(),
+                             "scatter_scalar source argument expects an array of scalars");
+    }
+    auto& scalar = *Scalar::Unwrap(source_array.Get(i).ToObject());
+    source.push_back(scalar);
+  }
+
+  // TODO XXX actually copy source_array to source
+
+  if (!Column::is_instance(args[1])) {
+    throw Napi::Error::New(info.Env(), "scatter_scalar indices argument expects a Column");
+  }
+  auto& indices = *Column::Unwrap(args[1]);
+
+  if (args.Length() == 2 or (args.Length() >= 2 and args[2].IsUndefined())) {
+    return scatter_scalar(source, indices)->Value();
+  }
+
+  if (args.Length() > 2 and args[2].IsBoolean()) {
+    auto check_bounds = NapiToCPP(args[2]);
+    if (args.Length() == 3) {
+      return scatter_scalar(source, indices, check_bounds)->Value();
+    } else if (args.Length() == 4 and args[2].IsBoolean()) {
+      auto* mr = NapiToCPP(info[3]).operator rmm::mr::device_memory_resource*();
+      return scatter_scalar(source, indices, check_bounds, mr)->Value();
+    }
+  }
+  NAPI_THROW(Napi::Error::New(Env(),
+                              "scatter_scalar expects a vector of scalars, a Column, and "
+                              "optionally a bool and memory resource"));
+}
+
+Napi::Value Table::scatter_table(Napi::CallbackInfo const& info) {
+  CallbackArgs args{info};
+
+  if (!Table::is_instance(args[0])) {
+    throw Napi::Error::New(info.Env(), "scatter_table source argument expects a Table");
+  }
+  auto& source = *Table::Unwrap(args[0]);
+
+  if (!Column::is_instance(args[1])) {
+    throw Napi::Error::New(info.Env(), "scatter_table indices argument expects a Column");
+  }
+  auto& indices = *Column::Unwrap(args[1]);
+
+  if (args.Length() == 2 or (args.Length() >= 2 and args[2].IsUndefined())) {
+    return scatter_table(source, indices)->Value();
+  }
+
+  if (args.Length() > 2 and args[2].IsBoolean()) {
+    auto check_bounds = NapiToCPP(args[2]);
+    if (args.Length() == 3) {
+      return scatter_table(source, indices, check_bounds)->Value();
+    } else if (args.Length() == 4 and args[2].IsBoolean()) {
+      auto* mr = NapiToCPP(info[3]).operator rmm::mr::device_memory_resource*();
+      return scatter_table(source, indices, check_bounds, mr)->Value();
+    }
+  }
+  NAPI_THROW(Napi::Error::New(
+    Env(), "scatter_table expects a Table, a Column, and optionally a bool and memory resource"));
 }
 
 }  // namespace nv

--- a/modules/cudf/src/table/copying.cpp
+++ b/modules/cudf/src/table/copying.cpp
@@ -88,14 +88,10 @@ Napi::Value Table::scatter_scalar(Napi::CallbackInfo const& info) {
 
   if (args.Length() > 2 and args[2].IsBoolean()) {
     auto check_bounds = NapiToCPP(args[2]);
-    if (args.Length() == 3) {
-      return scatter_scalar(source, indices, check_bounds)->Value();
-    } else if (args.Length() == 4 and args[2].IsBoolean()) {
-      auto* mr = NapiToCPP(info[3]).operator rmm::mr::device_memory_resource*();
-      return scatter_scalar(source, indices, check_bounds, mr)->Value();
-    }
+    auto* mr = NapiToCPP(info[3]).operator rmm::mr::device_memory_resource*();
+    return scatter_scalar(source, indices, check_bounds, mr)->Value();
   }
-  NAPI_THROW(Napi::Error::New(Env(),
+  NAPI_THROW(Napi::Error::New(info.Env(),
                               "scatter_scalar expects a vector of scalars, a Column, and "
                               "optionally a bool and memory resource"));
 }
@@ -119,15 +115,11 @@ Napi::Value Table::scatter_table(Napi::CallbackInfo const& info) {
 
   if (args.Length() > 2 and args[2].IsBoolean()) {
     auto check_bounds = NapiToCPP(args[2]);
-    if (args.Length() == 3) {
-      return scatter_table(source, indices, check_bounds)->Value();
-    } else if (args.Length() == 4 and args[2].IsBoolean()) {
-      auto* mr = NapiToCPP(info[3]).operator rmm::mr::device_memory_resource*();
-      return scatter_table(source, indices, check_bounds, mr)->Value();
-    }
+    auto* mr = NapiToCPP(info[3]).operator rmm::mr::device_memory_resource*();
+    return scatter_table(source, indices, check_bounds, mr)->Value();
   }
   NAPI_THROW(Napi::Error::New(
-    Env(), "scatter_table expects a Table, a Column, and optionally a bool and memory resource"));
+    info.Env(), "scatter_table expects a Table, a Column, and optionally a bool and memory resource"));
 }
 
 }  // namespace nv

--- a/modules/cudf/src/table/copying.cpp
+++ b/modules/cudf/src/table/copying.cpp
@@ -77,8 +77,6 @@ Napi::Value Table::scatter_scalar(Napi::CallbackInfo const& info) {
     source.push_back(scalar);
   }
 
-  // TODO XXX actually copy source_array to source
-
   if (!Column::is_instance(args[1])) {
     throw Napi::Error::New(info.Env(), "scatter_scalar indices argument expects a Column");
   }

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -153,6 +153,30 @@ test('Series.scatter (scalar with array indicies)', () => {
   expect([...col]).toEqual([0, 1, 999, 3, 999, 999, 6, 7, 999, 9]);
 });
 
+test('Series.scatter (check_bounds)', () => {
+  const col          = Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]});
+  const values       = Series.new({type: new Int32, data: [200, 400, 500, 800]});
+  const good_indices = [2, 4, 5, 8];
+  const bad_indices  = [2, 4, 5, 18];
+
+  col.scatter(values, good_indices, true);
+  col.scatter(999, good_indices, true);
+
+  col.scatter(values, bad_indices);
+  col.scatter(999, bad_indices);
+  expect(() => col.scatter(values, bad_indices, true)).toThrowError();
+  expect(() => col.scatter(999, bad_indices, true)).toThrowError();
+});
+
+test('Series.scatter (scalar)', () => {
+  const col     = Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]});
+  const indices = Series.new({type: new Int32, data: [2, 4, 5, 8]});
+
+  col.scatter(999, indices);
+
+  expect([...col]).toEqual([0, 1, 999, 3, 999, 999, 6, 7, 999, 9]);
+});
+
 test('Series.filter', () => {
   const col = Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
 

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -102,6 +102,25 @@ test('Series.gather', () => {
   expect([...result.toArrow()]).toEqual([...selection.toArrow()]);
 });
 
+test('Series.scatter (series)', () => {
+  const col     = Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]});
+  const values  = Series.new({type: new Int32, data: [200, 400, 500, 800]});
+  const indices = Series.new({type: new Int32, data: [2, 4, 5, 8]});
+
+  col.scatter(values, indices);
+
+  expect([...col]).toEqual([0, 1, 200, 3, 400, 500, 6, 7, 800, 9]);
+});
+
+test('Series.scatter (scalar)', () => {
+  const col     = Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]});
+  const indices = Series.new({type: new Int32, data: [2, 4, 5, 8]});
+
+  col.scatter(999, indices);
+
+  expect([...col]).toEqual([0, 1, 999, 3, 999, 999, 6, 7, 999, 9]);
+});
+
 test('Series.filter', () => {
   const col =
     Series.new({type: new Int32(), data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});


### PR DESCRIPTION
Supports scattering single scalars or other series:
```typescript
const col     = Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]});
const indices = Series.new({type: new Int32, data: [2, 4, 5, 8]});

col.scatter(999, indices);

const values  = Series.new({type: new Int32, data: [200, 400, 500, 800]});
col.scatter(values, indices);
```

Needs a few more tests but ready for a first review. 

Edit: added `setValue`