### PR TITLE
Build system fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,9 +141,9 @@ services:
       - *usr_share_icons
     environment:
       <<: *common_environment_variables
-      # Build for CUDA architecture sm_72
-      CUDAARCHS: "72-real"
-      JOBS: 2
+      # Build SASS and PTX for CUDA architecture sm_72
+      CUDAARCHS: "${CUDAARCHS:-72-real}"
+      PARALLEL_LEVEL: "${PARALLEL_LEVEL:-2}"
     cap_add:
       - SYS_ADMIN
       - SYS_PTRACE

--- a/modules/core/bin/cmake-js/linux.sh
+++ b/modules/core/bin/cmake-js/linux.sh
@@ -16,23 +16,27 @@ done
 if [[ "$debug" == "false" ]]; then
     args="${args:+$args }-O build/Release";
     compile_commands_json="build/Release/compile_commands.json";
+    args="${args:+$args }--CDCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(realpath -m build/Release)";
 else
     args="${args:+$args }-D -O build/Debug";
     compile_commands_json="build/Debug/compile_commands.json";
+    args="${args:+$args }--CDCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(realpath -m build/Debug)";
 fi
 
 RAPIDS_CORE_PATH=$(dirname $(realpath "$0"))
 RAPIDS_CORE_PATH=$(realpath "$RAPIDS_CORE_PATH/../../")
 RAPIDS_MODULES_PATH=$(realpath "$RAPIDS_CORE_PATH/../")
 
-if [ -z ${JOBS:+x} ]; then
-  JOBS=$(node -e "console.log(require('os').cpus().length-2)");
-fi
+echo "\
+=====================================================
+PARALLEL_LEVEL=${PARALLEL_LEVEL:-1}
+====================================================="
 
-PARALLEL_LEVEL=$JOBS CMAKE_BUILD_PARALLEL_LEVEL=$JOBS  \
+PARALLEL_LEVEL=${PARALLEL_LEVEL:-1}                    \
+CMAKE_BUILD_PARALLEL_LEVEL=${PARALLEL_LEVEL:-1}        \
 CCACHE_CONFIGPATH="$RAPIDS_MODULES_PATH/.cache/ccache" \
 HOME="$RAPIDS_CORE_PATH"                               \
-    cmake-js $args
+    cmake-js ${args}
 
 ln -f -s $compile_commands_json compile_commands.json
 

--- a/modules/core/bin/exec.js
+++ b/modules/core/bin/exec.js
@@ -1,41 +1,34 @@
 #!/usr/bin/env node
 
-var Path = require('path');
-var binp = Path.join(__dirname, '../', 'node_modules', '.bin');
-var opts = {
+module.exports = function (cmd, args, env = {}) {
+
+  require('dotenv').config();
+
+  var Path = require('path');
+  var env_ = Object.assign({}, process.env, env);
+  var binp = Path.join(__dirname, '../', 'node_modules', '.bin');
+  var opts = {
     shell: true,
     stdio: 'inherit',
     cwd: process.cwd(),
-    env: Object.assign({}, process.env, {
-        PATH: `${process.env.PATH}:${binp}` })
-};
+    env: Object.assign({}, env_, {
+      PATH: `${env_.PATH}:${binp}`
+    })
+  };
 
-module.exports = function(cmd, args) {
+  var name = (() => {
+    switch (require('os').platform()) {
+      case 'win32':
+        return 'windows.sh'
+      default:
+        return 'linux.sh'
+    }
+  })();
 
-    var name = (() => {
-        switch (require('os').platform()) {
-            case 'win32':
-                return 'windows.sh'
-            default:
-                return 'linux.sh'
-        }
-    })();
-
-    var proc = require('child_process').spawn(
-        Path.join(__dirname, cmd, name), args, opts);
-
-    ['SIGTERM', 'SIGINT', 'SIGBREAK', 'SIGHUP'].forEach((signal) => {
-        process.on(signal, () => proc.kill(signal))
-    });
-
-    proc.on('exit', (code, signal) => {
-        // exit code could be null when OS kills the process(out of memory, etc) or
-        // due to node handling it but if the signal is SIGINT the user exited the
-        // process so we want exit code 0
-        process.exit(code === null ? signal === 'SIGINT' ? 0 : 1 : code);
-    });
+  return require('child_process').spawnSync(
+    Path.join(__dirname, cmd, name), args, opts);
 }
 
 if (require.main === module) {
-    module.exports(process.argv[2], process.argv.slice(3));
+  module.exports(process.argv[2], process.argv.slice(3));
 }

--- a/modules/core/cmake/Modules/ConfigureCUDA.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDA.cmake
@@ -28,15 +28,15 @@ if(DEFINED ENV{CUDAARCHS})
     if("$ENV{CUDAARCHS}" STREQUAL "")
         # If CUDAARCHS is <empty_string>, auto-detect current GPU arch
         set(NODE_RAPIDS_CMAKE_BUILD_FOR_DETECTED_ARCHS TRUE)
-        message(STATUS "Auto-detecting GPU architecture because the CUDAARCH environment variable = '")
+        message(STATUS "Auto-detecting GPU architecture because the CUDAARCHS environment variable = '")
     elseif("$ENV{CUDAARCHS}" STREQUAL "ALL")
         # If CUDAARCHS is "ALL," build for all supported archs
         set(NODE_RAPIDS_CMAKE_BUILD_FOR_ALL_CUDA_ARCHS TRUE)
-        message(STATUS "Building all supported GPU architectures because the CUDAARCH environment variable = 'ALL'")
+        message(STATUS "Building all supported GPU architectures because the CUDAARCHS environment variable = 'ALL'")
     else()
         # Use the current value of the CUDAARCHS env var
         set(CMAKE_CUDA_ARCHITECTURES "$ENV{CUDAARCHS}")
-        message(STATUS "Using GPU architectures from CUDAARCH env var: $ENV{CUDAARCHS}")
+        message(STATUS "Using GPU architectures from CUDAARCHS env var: $ENV{CUDAARCHS}")
     endif()
 elseif(DEFINED CMAKE_CUDA_ARCHITECTURES)
     if(CMAKE_CUDA_ARCHITECTURES STREQUAL "")
@@ -54,7 +54,7 @@ elseif(DEFINED CMAKE_CUDA_ARCHITECTURES)
 else()
     # Fall-back to auto-detecting the current GPU architecture
     set(NODE_RAPIDS_CMAKE_BUILD_FOR_DETECTED_ARCHS TRUE)
-    message(STATUS "Auto-detecting GPU architectures because CUDAARCH env var is not defined, and CMAKE_CUDA_ARCHITECTURES was not specified.")
+    message(STATUS "Auto-detecting GPU architectures because CUDAARCHS env var is not defined, and CMAKE_CUDA_ARCHITECTURES was not specified.")
 endif()
 
 # Build the list of supported architectures
@@ -117,6 +117,14 @@ endif()
 message(STATUS "BUILD_FOR_DETECTED_ARCHS: ${NODE_RAPIDS_CMAKE_BUILD_FOR_DETECTED_ARCHS}")
 message(STATUS "BUILD_FOR_ALL_CUDA_ARCHS: ${NODE_RAPIDS_CMAKE_BUILD_FOR_ALL_CUDA_ARCHS}")
 message(STATUS "CMAKE_CUDA_ARCHITECTURES: ${CMAKE_CUDA_ARCHITECTURES}")
+
+if (NOT "${CMAKE_CUDA_ARCHITECTURES}" STREQUAL "75-real")
+    message(FATAL_ERROR "Expected CMAKE_CUDA_ARCHITECTURES to equal 75-real. Got ${CMAKE_CUDA_ARCHITECTURES}")
+endif()
+
+# Unset this first
+# unset(CMAKE_CUDA_ARCHITECTURES CACHE)
+set(CMAKE_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}" CACHE STRING "" FORCE)
 
 # Enable the CUDA language
 enable_language(CUDA)

--- a/modules/core/cmake/Modules/ConfigureCUDF.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDF.cmake
@@ -35,7 +35,7 @@ function(find_and_configure_cudf VERSION)
     set(DISABLE_DEPRECATION_WARNING ${DISABLE_DEPRECATION_WARNINGS})
     set(CUDF_GENERATED_INCLUDE_DIR ${NODE_RAPIDS_CPM_SOURCE_CACHE}/cudf-build)
 
-    CPMAddPackage(NAME  cudf
+    CPMFindPackage(NAME  cudf
         VERSION         ${VERSION}
         GIT_REPOSITORY  https://github.com/trxcllnt/cudf.git
         GIT_TAG         fix/async-set-value-literal

--- a/modules/core/cmake/Modules/ConfigureCUDF.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDF.cmake
@@ -38,7 +38,7 @@ function(find_and_configure_cudf VERSION)
     CPMFindPackage(NAME  cudf
         VERSION         ${VERSION}
         GIT_REPOSITORY  https://github.com/trxcllnt/cudf.git
-        GIT_TAG         fix/async-set-value-literal
+        GIT_TAG         nr/03232021
         GIT_SHALLOW     TRUE
         SOURCE_SUBDIR   cpp
         OPTIONS         "BUILD_TESTS OFF"

--- a/modules/core/cmake/Modules/ConfigureCUDF.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDF.cmake
@@ -24,6 +24,15 @@ function(find_and_configure_cudf VERSION)
                     OUTPUT_VARIABLE NODE_RAPIDS_CPM_SOURCE_CACHE
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+    # Have to set these in case configure and build steps are run separately
+    # TODO: figure out why
+    set(BUILD_TESTS OFF)
+    set(BUILD_BENCHMARKS OFF)
+    set(JITIFY_USE_CACHE ON)
+    set(CUDA_STATIC_RUNTIME ON)
+    set(CUDF_USE_ARROW_STATIC ON)
+    set(PER_THREAD_DEFAULT_STREAM ON)
+    set(DISABLE_DEPRECATION_WARNING ${DISABLE_DEPRECATION_WARNINGS})
     set(CUDF_GENERATED_INCLUDE_DIR ${NODE_RAPIDS_CPM_SOURCE_CACHE}/cudf-build)
 
     CPMAddPackage(NAME  cudf

--- a/modules/core/cmake/Modules/ConfigureCUSPATIAL.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUSPATIAL.cmake
@@ -42,7 +42,7 @@ function(find_and_configure_cuspatial VERSION)
         GIT_REPOSITORY  https://github.com/trxcllnt/cuspatial.git
         # Can also use a local path to your repo clone for testing
         # GIT_REPOSITORY  /home/ptaylor/dev/rapids/cuspatial
-        GIT_TAG         fix/async-set-value-literal
+        GIT_TAG         nr/03232021
         GIT_SHALLOW     TRUE
         SOURCE_SUBDIR   cpp
         OPTIONS         "BUILD_TESTS OFF"

--- a/modules/core/cmake/Modules/ConfigureCUSPATIAL.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUSPATIAL.cmake
@@ -35,7 +35,7 @@ function(find_and_configure_cuspatial VERSION)
     set(DISABLE_DEPRECATION_WARNING ${DISABLE_DEPRECATION_WARNINGS})
     set(CUDF_GENERATED_INCLUDE_DIR ${NODE_RAPIDS_CPM_SOURCE_CACHE}/cudf-build)
 
-    CPMAddPackage(NAME  cuspatial
+    CPMFindPackage(NAME  cuspatial
         VERSION         ${VERSION}
         # GIT_REPOSITORY https://github.com/rapidsai/cuspatial.git
         # GIT_TAG        branch-${VERSION}

--- a/modules/core/cmake/Modules/ConfigureCUSPATIAL.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUSPATIAL.cmake
@@ -24,6 +24,15 @@ function(find_and_configure_cuspatial VERSION)
                     OUTPUT_VARIABLE NODE_RAPIDS_CPM_SOURCE_CACHE
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+    # Have to set these in case configure and build steps are run separately
+    # TODO: figure out why
+    set(BUILD_TESTS OFF)
+    set(BUILD_BENCHMARKS OFF)
+    set(JITIFY_USE_CACHE ON)
+    set(CUDA_STATIC_RUNTIME ON)
+    set(CUDF_USE_ARROW_STATIC ON)
+    set(PER_THREAD_DEFAULT_STREAM ON)
+    set(DISABLE_DEPRECATION_WARNING ${DISABLE_DEPRECATION_WARNINGS})
     set(CUDF_GENERATED_INCLUDE_DIR ${NODE_RAPIDS_CPM_SOURCE_CACHE}/cudf-build)
 
     CPMAddPackage(NAME  cuspatial

--- a/modules/core/cmake/Modules/ConfigureCXX.cmake
+++ b/modules/core/cmake/Modules/ConfigureCXX.cmake
@@ -32,9 +32,9 @@ if(NODE_RAPIDS_USE_CCACHE)
             set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM_PATH}")
         else()
             execute_process(COMMAND node -p
-                            "require('@rapidsai/core').modules_path"
+                            "require('@rapidsai/core').project_root_dir_path"
                             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                            OUTPUT_VARIABLE NODE_RAPIDS_MODULES_BASE_DIR
+                            OUTPUT_VARIABLE NODE_RAPIDS_BASE_DIR
                             OUTPUT_STRIP_TRAILING_WHITESPACE)
             execute_process(COMMAND node -p
                             "require('@rapidsai/core').cmake_modules_path"
@@ -66,6 +66,24 @@ execute_process(COMMAND node -p
 
 set(ENV{CPM_SOURCE_CACHE} ${NODE_RAPIDS_CPM_SOURCE_CACHE})
 message(STATUS "Using CPM source cache: $ENV{CPM_SOURCE_CACHE}")
+
+if (NOT DEFINED ENV{NODE_RAPIDS_USE_LOCAL_DEPS_BUILD_DIRS})
+    execute_process(COMMAND node -p
+                    "require('@rapidsai/core').cmake_fetchcontent_base"
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    OUTPUT_VARIABLE NODE_RAPIDS_FETCHCONTENT_BASE_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    set(FETCHCONTENT_BASE_DIR "${NODE_RAPIDS_FETCHCONTENT_BASE_DIR}")
+    message(STATUS "Using CMake FetchContent base dir: ${FETCHCONTENT_BASE_DIR}")
+
+    # Can't set these yet because the order of include paths is different
+    # when using libcudf from a build dir vs. CPM running the CMakeLists.txt.
+    # set(rmm_ROOT "${FETCHCONTENT_BASE_DIR}/rmm-build")
+    # set(cudf_ROOT "${FETCHCONTENT_BASE_DIR}/cudf-build")
+    # # set(cugraph_ROOT "${FETCHCONTENT_BASE_DIR}/cugraph-build")
+    # set(cuspatial_ROOT "${FETCHCONTENT_BASE_DIR}/cuspatial-build")
+endif()
 
 execute_process(COMMAND node -p
                 "require('@rapidsai/core').cpp_include_path"

--- a/modules/core/cmake/Modules/ConfigureCuGraph.cmake
+++ b/modules/core/cmake/Modules/ConfigureCuGraph.cmake
@@ -19,7 +19,7 @@ function(find_and_configure_cugraph VERSION)
     include(get_cpm)
     include(ConfigureRAFT)
 
-    CPMAddPackage(NAME cugraph
+    CPMFindPackage(NAME cugraph
         VERSION        ${CUGRAPH_VERSION}
         GIT_REPOSITORY https://github.com/rapidsai/cugraph.git
         GIT_TAG        branch-${CUGRAPH_VERSION}

--- a/modules/core/cmake/Modules/ConfigureOpenGLEW.cmake
+++ b/modules/core/cmake/Modules/ConfigureOpenGLEW.cmake
@@ -18,7 +18,7 @@ include(get_cpm)
 
 add_compile_definitions(GLEW_EGL)
 
-CPMAddPackage(NAME glew
+CPMFindPackage(NAME glew
     VERSION        ${GLEW_VERSION}
     GIT_REPOSITORY https://github.com/Perlmint/glew-cmake.git
     GIT_TAG        glew-cmake-${GLEW_VERSION}

--- a/modules/core/cmake/Modules/ConfigureOpenGLFW.cmake
+++ b/modules/core/cmake/Modules/ConfigureOpenGLFW.cmake
@@ -22,7 +22,7 @@ else()
     set(GLFW_GIT_BRANCH_NAME "${GLFW_VERSION}")
 endif()
 
-CPMAddPackage(NAME glfw
+CPMFindPackage(NAME glfw
     VERSION        ${GLFW_VERSION}
     GIT_REPOSITORY https://github.com/glfw/glfw.git
     GIT_TAG        ${GLFW_GIT_BRANCH_NAME}

--- a/modules/core/cmake/Modules/ConfigureRAFT.cmake
+++ b/modules/core/cmake/Modules/ConfigureRAFT.cmake
@@ -18,7 +18,7 @@ function(find_and_configure_raft VERSION)
 
     include(get_cpm)
 
-    CPMAddPackage(NAME raft
+    CPMFindPackage(NAME raft
         VERSION        ${RAFT_VERSION}
         GIT_REPOSITORY https://github.com/rapidsai/raft.git
         GIT_TAG        ${RAFT_BRANCH}

--- a/modules/core/cmake/Modules/ConfigureRMM.cmake
+++ b/modules/core/cmake/Modules/ConfigureRMM.cmake
@@ -18,7 +18,7 @@ function(find_and_configure_rmm VERSION)
 
     include(get_cpm)
 
-    CPMAddPackage(NAME rmm
+    CPMFindPackage(NAME rmm
         VERSION        ${RMM_VERSION}
         GIT_REPOSITORY https://github.com/rapidsai/rmm.git
         GIT_TAG        branch-${RMM_VERSION}

--- a/modules/core/cmake/Modules/ccache.conf.in
+++ b/modules/core/cmake/Modules/ccache.conf.in
@@ -1,9 +1,9 @@
-max_size = 0
-hash_dir = false
+max_size=0
+hash_dir=false
 # let ccache preserve C++ comments, because some of them may be meaningful to the compiler
-keep_comments_cpp = true
-base_dir = @NODE_RAPIDS_MODULES_BASE_DIR@
-cache_dir = @NODE_RAPIDS_CMAKE_CCACHE_DIR@
-compiler_check = %compiler% --version
+keep_comments_cpp=true
+base_dir=@NODE_RAPIDS_BASE_DIR@
+cache_dir=@NODE_RAPIDS_CMAKE_CCACHE_DIR@
+compiler_check=%compiler% --version
 # Uncomment to debug ccache preprocessor errors/cache misses
-# log_file = @NODE_RAPIDS_CMAKE_CCACHE_DIR@/ccache.log
+# log_file=@NODE_RAPIDS_CMAKE_CCACHE_DIR@/ccache.log

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "25.2.2",
+    "dotenv": "8.2.0",
     "jest": "26.6.3",
     "jest-silent-reporter": "0.1.2",
     "esm": "3.2.25",

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -18,6 +18,8 @@ export * from './loadnativemodule';
 
 export const modules_path = Path.resolve(__dirname, '..', '..', '..');
 
+export const project_root_dir_path = Path.resolve(modules_path, '..');
+
 export const ccache_path = Path.resolve(modules_path, '.cache', 'ccache');
 
 export const cpm_source_cache_path = Path.resolve(modules_path, '.cache', 'cpm');
@@ -25,3 +27,5 @@ export const cpm_source_cache_path = Path.resolve(modules_path, '.cache', 'cpm')
 export const cpp_include_path = Path.resolve(modules_path, 'core', 'include');
 
 export const cmake_modules_path = Path.resolve(modules_path, 'core', 'cmake', 'Modules');
+
+export const cmake_fetchcontent_base = Path.resolve(modules_path, '.cache', 'build');

--- a/modules/demo/deck/3d-heatmap/package.json
+++ b/modules/demo/deck/3d-heatmap/package.json
@@ -16,7 +16,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/3d-tiles/package.json
+++ b/modules/demo/deck/3d-tiles/package.json
@@ -18,7 +18,7 @@
     "@loaders.gl/3d-tiles": "^2.1.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/ShanghaiData/package.json
+++ b/modules/demo/deck/ShanghaiData/package.json
@@ -15,7 +15,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/arc/package.json
+++ b/modules/demo/deck/arc/package.json
@@ -16,7 +16,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/brushing/package.json
+++ b/modules/demo/deck/brushing/package.json
@@ -16,7 +16,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/data-filter/package.json
+++ b/modules/demo/deck/data-filter/package.json
@@ -17,7 +17,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0",
+    "react-map-gl": "6.1.10",
     "styletron-engine-atomic": "^1.4.0",
     "styletron-react": "^5.2.0"
   },

--- a/modules/demo/deck/geojson/package.json
+++ b/modules/demo/deck/geojson/package.json
@@ -16,7 +16,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/heatmap/package.json
+++ b/modules/demo/deck/heatmap/package.json
@@ -15,7 +15,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/highway/package.json
+++ b/modules/demo/deck/highway/package.json
@@ -17,7 +17,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/icon/package.json
+++ b/modules/demo/deck/icon/package.json
@@ -15,7 +15,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0",
+    "react-map-gl": "6.1.10",
     "supercluster": "^6.0.1"
   },
   "devDependencies": {

--- a/modules/demo/deck/line/package.json
+++ b/modules/demo/deck/line/package.json
@@ -15,7 +15,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/playground/package.json
+++ b/modules/demo/deck/playground/package.json
@@ -24,7 +24,7 @@
     "react": "~16.9.0",
     "react-ace": "^6.1.4",
     "react-dom": "~16.9.0",
-    "react-map-gl": "^5.0.0",
+    "react-map-gl": "6.1.10",
     "react-virtualized-auto-sizer": "^1.0.2"
   },
   "devDependencies": {

--- a/modules/demo/deck/scatterplot/package.json
+++ b/modules/demo/deck/scatterplot/package.json
@@ -15,7 +15,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/scenegraph-layer/package.json
+++ b/modules/demo/deck/scenegraph-layer/package.json
@@ -16,7 +16,7 @@
     "@loaders.gl/gltf": "^2.1.1",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/screen-grid/package.json
+++ b/modules/demo/deck/screen-grid/package.json
@@ -15,7 +15,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/tagmap/package.json
+++ b/modules/demo/deck/tagmap/package.json
@@ -16,7 +16,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0",
+    "react-map-gl": "6.1.10",
     "tagmap.js": "^1.1.1"
   },
   "devDependencies": {

--- a/modules/demo/deck/text-layer/package.json
+++ b/modules/demo/deck/text-layer/package.json
@@ -15,7 +15,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/trips/package.json
+++ b/modules/demo/deck/trips/package.json
@@ -15,7 +15,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/modules/demo/deck/worldmap/package.json
+++ b/modules/demo/deck/worldmap/package.json
@@ -16,7 +16,7 @@
     "deck.gl": "^8.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react-map-gl": "6.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/node-rapids.code-workspace
+++ b/node-rapids.code-workspace
@@ -171,7 +171,6 @@
     "files.exclude": {
       "**/.git": true,
       "**/.DS_Store": true,
-      "**/.cache": true,
       "**/.cmake-js": true
     },
     "files.watcherExclude": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@typescript-eslint/eslint-plugin": "4.17.0",
     "@typescript-eslint/parser": "4.17.0",
     "cmake-js": "6.0.0",
+    "dotenv": "8.2.0",
     "eslint": "7.22.0",
     "lerna": "3.22.1",
     "lint-staged": "10.5.1",

--- a/scripts/exec.js
+++ b/scripts/exec.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+require('dotenv').config();
+
 var name = (() => {
   switch (require('os').platform()) {
     case 'win32': return 'win32.sh';
@@ -7,12 +9,12 @@ var name = (() => {
   }
 })();
 
-var Path    = require('path');
+var Path = require('path');
 var rootdir = Path.join(__dirname, '../');
 var cmdpath = Path.join(__dirname, process.argv[2]);
-var cwd     = Path.join(cmdpath, Path.relative(cmdpath, rootdir));
+var cwd = Path.join(cmdpath, Path.relative(cmdpath, rootdir));
 
 require('child_process')
   .spawnSync(Path.join(cmdpath, name),  // command
-             process.argv.slice(3),
-             {stdio: 'inherit', cwd});
+    process.argv.slice(3),
+    { stdio: 'inherit', cwd });

--- a/scripts/relink-bin-dirs/linux.sh
+++ b/scripts/relink-bin-dirs/linux.sh
@@ -24,6 +24,8 @@ for DIR in $DIRS; do
     if [[ "$BIN" != $DIR/node_modules/.bin ]]; then
         rm -rf "$DIR/node_modules/.bin"
         ln -sf "$BIN" "$DIR/node_modules/.bin"
+        # copy the .env settings file
+        touch ".env" && cp ".env" "$DIR/.env"
         # copy the ESLint settings file (for the VSCode ESLint plugin)
         cp ".eslintrc.js" "$DIR/.eslintrc.js"
         # remove the local .cache symlink

--- a/yarn.lock
+++ b/yarn.lock
@@ -6302,6 +6302,11 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 draco3d@^1.3.6:
   version "1.4.1"
   resolved "https://registry.npmjs.org/draco3d/-/draco3d-1.4.1.tgz#2abdcf7b59caaac50f7e189aec454176c57146b2"
@@ -6348,9 +6353,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.649:
-  version "1.3.693"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.693.tgz#5089c506a925c31f93fcb173a003a22e341115dd"
-  integrity sha512-vUdsE8yyeu30RecppQtI+XTz2++LWLVEIYmzeCaCRLSdtKZ2eXqdJcrs85KwLiPOPVc6PELgWyXBsfqIvzGZag==
+  version "1.3.694"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.694.tgz#f5dbbec0ce9bbf93487b7d38b8396f4e58ab51c8"
+  integrity sha512-8YJ/OZjbK5luOd27dmk34B47oa/zNGRHrKTEmfO3qPns1kFAJ36Lb+OtYzNlCoXtkPYuDbX0ztofuL7ArMHJkQ==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -12072,16 +12077,16 @@ react-is@^16.12.0, react-is@^16.3.2, react-is@^16.8.1, react-is@^16.8.6:
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
-  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+  version "17.0.2"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-map-gl@6.1.10, react-map-gl@^5.0.0, react-map-gl@^5.1.0:
+react-map-gl@6.1.10, react-map-gl@^5.1.0:
   version "6.1.10"
   resolved "https://registry.npmjs.org/react-map-gl/-/react-map-gl-6.1.10.tgz#8616562d1439f5718c02e5a69379d8f200f7a099"
   integrity sha512-TZ0GSMSY3fK6bh5wTnoUHdJRyhJLmr2flZBonTR+7Br5Q/iAtOSnr5PMH8G/IE9KZ8AmwpyzdujvQXTI3ZycUA==
@@ -12438,9 +12443,9 @@ regjsgen@^0.5.1:
   integrity sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==
 
 regjsparser@^0.6.4:
-  version "0.6.7"
-  resolved "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.7.tgz#c00164e1e6713c2e3ee641f1701c4b7aa0a7f86c"
-  integrity sha512-ib77G0uxsA2ovgiYbCVGx4Pv3PSttAx2vIwidqQzbL2U5S4Q+j00HdSAneSBuyVcMvEnTXMjiGgB+DlXozVhpQ==
+  version "0.6.8"
+  resolved "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.8.tgz#4532c3da36d75d56e3f394ce2ea6842bde7496bd"
+  integrity sha512-3weFrFQREJhJ2PW+iCGaG6TenyzNSZgsBKZ/oEf6Trme31COSeIWhHw9O6FPkuXktfx+b6Hf/5e6dKPHaROq2g==
   dependencies:
     jsesc "~0.5.0"
 
@@ -12911,9 +12916,9 @@ semver@7.0.0:
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
 semver@7.x, semver@^7.0.0, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
-  version "7.3.4"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
-  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  version "7.3.5"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
* Fix discrepancies in CMake CUDA architecture selection when configure/build are done separately
* Fix ccache's `base_dir` to point to the repo root so ccache can handle the `node-addon-api` include paths in `<root>/node_modules`
* Set PARALLEL_LEVEL=1 as default when building, use [`dotenv`](https://www.npmjs.com/package/dotenv) to read `.env` file for custom env overrides
* Use common build directories for CPM dependencies, so cuDF/cuGraph/cuSpatial bindings don't all end up recompiling `cuDF`
* Updates branches for `libcudf`/`libcuspatial` to take advantage of [compile-time optimizations for a smaller `libcudf.so`](https://github.com/rapidsai/cudf/pull/7583)

Branched from https://github.com/rapidsai/node-rapids/pull/128