### PR TITLE
Update github action paths

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,7 @@ on:
       - '**/typedoc.js'
       - 'modules/**/src/**/*.ts'
       - '.github/workflows/**'
+      - 'README.md'
 
 jobs:
   update:


### PR DESCRIPTION
From looking at the docs site (https://rapidsai.github.io/node-rapids/), it seems that the docs use the repo's [README.md](https://github.com/rapidsai/node-rapids/blob/main/README.md) file for the index page.

This PR updates the GitHub Action that publishes the docs to run anytime the `README.md` file is changed.