### PR TITLE
Update default TypeScript Installation

### DIFF
--- a/node-rapids.code-workspace
+++ b/node-rapids.code-workspace
@@ -190,6 +190,7 @@
       "**/.cache/**": true,
       "**/.cmake-js/**": true,
       "**/node_modules/**": true
-    }
+    },
+    "typescript.tsdk": "node-rapids/node_modules/typescript/lib"
   }
 }


### PR DESCRIPTION
This PR adds a `typescript.tsdk` entry to the workspace file, which sets the default TypeScript installation that should be used by VS Code in the workspace.