### PR TITLE
CPM and groupBy types followup

### DIFF
--- a/modules/core/cmake/Modules/ConfigureCUDF.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDF.cmake
@@ -31,23 +31,12 @@ function(find_and_configure_cudf VERSION)
     include(ConfigureRMM)
 
     if(NOT TARGET cudf::cudf)
-
-        if (NOT DEFINED ENV{NODE_RAPIDS_USE_LOCAL_DEPS_BUILD_DIRS})
-            if (EXISTS "${FETCHCONTENT_BASE_DIR}/thrust-subbuild")
-                file(REMOVE_RECURSE "${FETCHCONTENT_BASE_DIR}/thrust-subbuild")
-            endif()
-        endif()
-
-        execute_process(COMMAND node -p
-                        "require('@rapidsai/core').cpm_source_cache_path"
-                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                        OUTPUT_VARIABLE NODE_RAPIDS_CPM_SOURCE_CACHE
-                        OUTPUT_STRIP_TRAILING_WHITESPACE)
-
         CPMFindPackage(NAME     cudf
             VERSION             ${VERSION}
-            GIT_REPOSITORY      https://github.com/rapidsai/cudf.git
-            GIT_TAG             branch-${VERSION}
+            # GIT_REPOSITORY      https://github.com/rapidsai/cudf.git
+            # GIT_TAG             branch-${VERSION}
+            GIT_REPOSITORY      https://github.com/trxcllnt/cudf.git
+            GIT_TAG             fix/cpm-v0.32.1
             GIT_SHALLOW         TRUE
             UPDATE_DISCONNECTED FALSE
             SOURCE_SUBDIR       cpp

--- a/modules/core/cmake/Modules/ConfigureCUSPATIAL.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUSPATIAL.cmake
@@ -25,17 +25,12 @@ function(find_and_configure_cuspatial VERSION)
     include(ConfigureCUDF)
 
     if(NOT TARGET cuspatial::cuspatial)
-
-        execute_process(COMMAND node -p
-                        "require('@rapidsai/core').cpm_source_cache_path"
-                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                        OUTPUT_VARIABLE NODE_RAPIDS_CPM_SOURCE_CACHE
-                        OUTPUT_STRIP_TRAILING_WHITESPACE)
-
         CPMFindPackage(NAME     cuspatial
             VERSION             ${VERSION}
-            GIT_REPOSITORY      https://github.com/rapidsai/cuspatial.git
-            GIT_TAG             branch-${VERSION}
+            # GIT_REPOSITORY      https://github.com/rapidsai/cuspatial.git
+            # GIT_TAG             branch-${VERSION}
+            GIT_REPOSITORY      https://github.com/trxcllnt/cuspatial.git
+            GIT_TAG             fix/cpm-v0.32.1
             GIT_SHALLOW         TRUE
             UPDATE_DISCONNECTED FALSE
             SOURCE_SUBDIR       cpp

--- a/modules/core/cmake/Modules/ConfigureRMM.cmake
+++ b/modules/core/cmake/Modules/ConfigureRMM.cmake
@@ -23,13 +23,6 @@ function(find_and_configure_rmm VERSION)
     _set_package_dir_if_exists(Thrust thrust)
 
     if(NOT TARGET rmm::rmm)
-
-        if (NOT DEFINED ENV{NODE_RAPIDS_USE_LOCAL_DEPS_BUILD_DIRS})
-            if (EXISTS "${FETCHCONTENT_BASE_DIR}/thrust-subbuild")
-                file(REMOVE_RECURSE "${FETCHCONTENT_BASE_DIR}/thrust-subbuild")
-            endif()
-        endif()
-
         CPMFindPackage(NAME     rmm
             VERSION             ${RMM_VERSION}
             GIT_REPOSITORY      https://github.com/rapidsai/rmm.git

--- a/modules/core/cmake/Modules/get_cpm.cmake
+++ b/modules/core/cmake/Modules/get_cpm.cmake
@@ -89,7 +89,7 @@ endfunction()
 
 function(_clean_build_dirs_if_not_fully_built dir soname)
     if (NOT DEFINED ENV{NODE_RAPIDS_USE_LOCAL_DEPS_BUILD_DIRS})
-        if (NOT (EXISTS "${CPM_BINARY_CACHE}/${dir}-build/${soname}"))
+        if (EXISTS "${CPM_BINARY_CACHE}/${dir}-build/${soname}")
             message(STATUS "get_cpm: not clearing shared build dirs since '${CPM_BINARY_CACHE}/${dir}-build/${soname}' exists")
         else()
             file(REMOVE_RECURSE "${CPM_BINARY_CACHE}/${dir}-build")

--- a/modules/cudf/src/groupby/single.ts
+++ b/modules/cudf/src/groupby/single.ts
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 import {MemoryResource} from '@rapidsai/rmm';
-import {Int32} from 'apache-arrow';
 
 import {Column} from '../column';
 import {DataFrame, SeriesMap} from '../data_frame';
 import {Series} from '../series';
 import {Table} from '../table';
-import {DataType} from '../types/dtypes';
+import {DataType, Int32} from '../types/dtypes';
 import {Interpolation, TypeMap} from '../types/mappings';
 
 import {GroupByBase, GroupByBaseProps} from './base';
@@ -49,7 +48,7 @@ export class GroupBySingle<T extends TypeMap, R extends keyof T> extends GroupBy
    *   device memory.
    */
   argmax(memoryResource?: MemoryResource) {
-    return this.prepare_results<{[P in R]: T[P]}&{[P in keyof T]: Int32}>(
+    return this.prepare_results<{[P in keyof T]: P extends R ? T[P] : Int32}>(
       this._cudf_groupby._argmax(this._values.asTable(), memoryResource));
   }
 
@@ -60,7 +59,7 @@ export class GroupBySingle<T extends TypeMap, R extends keyof T> extends GroupBy
    *   device memory.
    */
   argmin(memoryResource?: MemoryResource) {
-    return this.prepare_results<{[P in R]: T[P]}&{[P in keyof T]: Int32}>(
+    return this.prepare_results<{[P in keyof T]: P extends R ? T[P] : Int32}>(
       this._cudf_groupby._argmin(this._values.asTable(), memoryResource));
   }
 
@@ -71,7 +70,7 @@ export class GroupBySingle<T extends TypeMap, R extends keyof T> extends GroupBy
    *   device memory.
    */
   count(memoryResource?: MemoryResource) {
-    return this.prepare_results<{[P in R]: T[P]}&{[P in keyof T]: Int32}>(
+    return this.prepare_results<{[P in keyof T]: P extends R ? T[P] : Int32}>(
       this._cudf_groupby._count(this._values.asTable(), memoryResource));
   }
 
@@ -136,7 +135,7 @@ export class GroupBySingle<T extends TypeMap, R extends keyof T> extends GroupBy
    *   device memory.
    */
   nunique(memoryResource?: MemoryResource) {
-    return this.prepare_results<{[P in R]: T[P]}&{[P in keyof T]: Int32}>(
+    return this.prepare_results<{[P in keyof T]: P extends R ? T[P] : Int32}>(
       this._cudf_groupby._nunique(this._values.asTable(), memoryResource));
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3304,19 +3304,19 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@>= 8", "@types/node@^14.0.0":
-  version "14.14.37"
-  resolved "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
-  integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
+  version "14.14.41"
+  resolved "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
+  integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
 "@types/node@^12.0.4":
-  version "12.20.7"
-  resolved "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz#1cb61fd0c85cb87e728c43107b5fd82b69bc9ef8"
-  integrity sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==
+  version "12.20.10"
+  resolved "https://registry.npmjs.org/@types/node/-/node-12.20.10.tgz#4dcb8a85a8f1211acafb88d72fafc7e3d2685583"
+  integrity sha512-TxCmnSSppKBBOzYzPR2BR25YlX5Oay8z2XGwFBInuA/Co0V9xJhLlW4kjbxKtgeNo3NOMbQP1A5Rc03y+XecPw==
 
 "@types/node@^13.7.4":
-  version "13.13.48"
-  resolved "https://registry.npmjs.org/@types/node/-/node-13.13.48.tgz#46a3df718aed5217277f2395a682e055a487e341"
-  integrity sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ==
+  version "13.13.50"
+  resolved "https://registry.npmjs.org/@types/node/-/node-13.13.50.tgz#bc8ebf70c392a98ffdba7aab9b46989ea96c1c62"
+  integrity sha512-y7kkh+hX/0jZNxMyBR/6asG0QMSaPSzgeVK63dhWHl4QAXCQB8lExXmzLL6SzmOgKHydtawpMnNhlDbv7DXPEA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4833,9 +4833,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001208:
-  version "1.0.30001208"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz#a999014a35cebd4f98c405930a057a0d75352eb9"
-  integrity sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
+  version "1.0.30001209"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz#1bb4be0bd118e98e21cfb7ef617b1ef2164622f4"
+  integrity sha512-2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA==
 
 canvas@^2.6.1:
   version "2.7.0"
@@ -6056,14 +6056,14 @@ d3-scale-chromatic@2:
     d3-interpolate "1 - 2"
 
 d3-scale@3, d3-scale@^3.2.1, d3-scale@^3.2.2, d3-scale@^3.2.3:
-  version "3.2.4"
-  resolved "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.4.tgz#13d758d7cf4e4f1fc40196a63597d01f3ed81765"
-  integrity sha512-PG6gtpbPCFqKbvdBEswQcJcTzHC8VEd/XzezF5e68KlkT4/ggELw/nR1tv863jY6ufKTvDlzCMZvhe06codbbA==
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz#28c600b29f47e5b9cd2df9749c206727966203f3"
+  integrity sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==
   dependencies:
     d3-array "^2.3.0"
     d3-format "1 - 2"
     d3-interpolate "1.2.0 - 2"
-    d3-time "1 - 2"
+    d3-time "^2.1.1"
     d3-time-format "2 - 3"
 
 d3-scale@3.2.1:
@@ -6132,7 +6132,7 @@ d3-time@1:
   resolved "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
-"d3-time@1 - 2", d3-time@2, d3-time@^2.0.0:
+"d3-time@1 - 2", d3-time@2, d3-time@^2.0.0, d3-time@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz#e9d8a8a88691f4548e68ca085e5ff956724a6682"
   integrity sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==
@@ -6701,9 +6701,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.634, electron-to-chromium@^1.3.712:
-  version "1.3.714"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.714.tgz#dabe0b67bd9463bcef5d25fe141daf8de7f93ea3"
-  integrity sha512-/xC2dSRZTzpPuKF/v+YZSYSkS0ZzktGrqou/ldu3MovPdEuLBzU/QUfEAc1as/M/KMbM5HZFQDs7/edNmSOpNA==
+  version "1.3.717"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz#78d4c857070755fb58ab64bcc173db1d51cbc25f"
+  integrity sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -14419,9 +14419,9 @@ table-layout@^0.4.3:
     wordwrapjs "^3.0.0"
 
 table@^6.0.4:
-  version "6.0.9"
-  resolved "https://registry.npmjs.org/table/-/table-6.0.9.tgz#790a12bf1e09b87b30e60419bafd6a1fd85536fb"
-  integrity sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/table/-/table-6.1.0.tgz#676a0cfb206008b59e783fcd94ef8ba7d67d966c"
+  integrity sha512-T4G5KMmqIk6X87gLKWyU5exPpTjLjY5KyrFWaIjv3SvgaIUGXV7UEzGEnZJdTA38/yUS6f9PlKezQ0bYXG3iIQ==
   dependencies:
     ajv "^8.0.1"
     is-boolean-object "^1.1.0"
@@ -15001,9 +15001,9 @@ uncontrollable@^7.0.0, uncontrollable@^7.2.1:
     react-lifecycles-compat "^3.0.4"
 
 underscore@>=1.7.0:
-  version "1.13.0"
-  resolved "https://registry.npmjs.org/underscore/-/underscore-1.13.0.tgz#3ccdcbb824230fc6bf234ad0ddcd83dff4eafe5f"
-  integrity sha512-sCs4H3pCytsb5K7i072FAEC9YlSYFIbosvM0tAKAlpSSUgD7yC1iXSEGdl5XrDKQ1YUB+p/HDzYrSG2H2Vl36g==
+  version "1.13.1"
+  resolved "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
+  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
* Fixes groupBy types causing tests/docs to not type-check
* Temporarily switch to cuDF/cuSpatial branches with the newer CPM
* Fix CMake function logic that would cause it to delete the local build dir