### PR TITLE
Doc/add sample code to dataframe and series functions

### DIFF
--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -64,16 +64,52 @@ export class DataFrame<T extends TypeMap = any> {
 
   /**
    * The number of rows in each column of this DataFrame
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new([1, 2]),
+   *  b: Series.new([1, 2]),
+   *  c: Series.new([1, 2])
+   * })
+   *
+   * df.numRows // 2
+   * ```
    */
   get numRows() { return this._accessor.columns[0].length; }
 
   /**
    * The number of columns in this DataFrame
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new([1, 2]),
+   *  b: Series.new([1, 2]),
+   *  c: Series.new([1, 2])
+   * })
+   *
+   * df.numColumns // 3
+   * ```
    */
   get numColumns() { return this._accessor.length; }
 
   /**
    * The names of columns in this DataFrame
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new([1, 2]),
+   *  b: Series.new([1, 2]),
+   *  c: Series.new([1, 2])
+   * })
+   *
+   * df.names // ['a', 'b', 'c']
+   * ```
    */
   get names() { return this._accessor.names; }
 
@@ -84,6 +120,18 @@ export class DataFrame<T extends TypeMap = any> {
    * Return a new DataFrame containing only specified columns.
    *
    * @param columns Names of columns keep.
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new([0, 1, 1, 2, 2, 2]),
+   *  b: Series.new([0, 1, 2, 3, 4, 4]),
+   *  c: Series.new([1, 2, 3, 4, 5, 6])
+   * })
+   *
+   * df.select(['a', 'b']) // returns df with {a, b}
+   * ```
    */
   select<R extends keyof T>(names: R[]) {
     return new DataFrame(this._accessor.selectByColumnNames(names));
@@ -92,14 +140,34 @@ export class DataFrame<T extends TypeMap = any> {
   /**
    * Return a new DataFrame with new columns added.
    *
-   *  @param data mapping of names to new columns to add
+   * @param data mapping of names to new columns to add
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame} from '@rapidsai/cudf';
+   *
+   * const df = new DataFrame({a: [1, 2, 3]});
+   *
+   * df.assign({b: ["foo", "bar", "bar"]})
+   * // returns df {a: [1, 2, 3], b: ["foo", "bar", "bar"]}
+   * ```
    */
   assign<R extends TypeMap>(data: SeriesMap<R>): DataFrame<T&R>;
 
   /**
    * Return a new DataFrame with new columns added.
    *
-   *  @param data a GPU DataFrame object
+   * @param data a GPU DataFrame object
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame} from '@rapidsai/cudf';
+   *
+   * const df = new DataFrame({a: [1, 2, 3]});
+   * const df1 = new DataFrame({b: ["foo", "bar", "bar"]});
+   *
+   * df.assign(df1) // returns df {a: [1, 2, 3], b: ["foo", "bar", "bar"]}
+   * ```
    */
   assign<R extends TypeMap>(data: DataFrame<R>): DataFrame<T&R>;
 
@@ -112,6 +180,17 @@ export class DataFrame<T extends TypeMap = any> {
    * Return a new DataFrame with specified columns removed.
    *
    * @param names Names of the columns to drop.
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Int32, Float32}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new({type: new Int32, data: [0, 1, 1, 2, 2, 2]}),
+   *  b: Series.new({type: new Float32, data: [0, 1, 2, 3, 4, 4]})
+   * });
+   *
+   * df.drop(['a']) // returns df {b: [0, 1, 2, 3, 4, 4]}
+   * ```
    */
   drop<R extends keyof T>(names: R[]) { return new DataFrame(this._accessor.dropColumns(names)); }
 
@@ -119,6 +198,18 @@ export class DataFrame<T extends TypeMap = any> {
    * Return whether the DataFrame has a Series.
    *
    * @param name Name of the Series to return.
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Int32, Float32}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new({type: new Int32, data: [0, 1, 1, 2, 2, 2]}),
+   *  b: Series.new({type: new Float32, data: [0, 1, 2, 3, 4, 4]})
+   * });
+   *
+   * df.has('a') // true
+   * df.has('c') // false
+   * ```
    */
   has(name: string) { return this._accessor.has(name); }
 
@@ -126,6 +217,18 @@ export class DataFrame<T extends TypeMap = any> {
    * Return a series by name.
    *
    * @param name Name of the Series to return.
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Int32, Float32}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new({type: new Int32, data: [0, 1, 1, 2, 2, 2]}),
+   *  b: Series.new({type: new Float32, data: [0, 1, 2, 3, 4, 4]})
+   * });
+   *
+   * df.get('a') // Int32Series { _col: Column {} }
+   * df.get('b') // Float32Series  { _col: Column {} }
+   * ```
    */
   get<P extends keyof T>(name: P): Series<T[P]> { return Series.new(this._accessor.get(name)); }
 
@@ -136,6 +239,17 @@ export class DataFrame<T extends TypeMap = any> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns DataFrame of Series cast to the new dtype
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Int32, Float32}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new({type: new Int32, data: [0, 1, 1, 2, 2, 2]}),
+   *  b: Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 4]})
+   * });
+   *
+   * df.cast({a: new Float32}); // returns df with a as Float32Series and b as Int32Series
+   * ```
    */
   cast<R extends {[P in keyof T]?: DataType}>(dataTypes: R, memoryResource?: MemoryResource) {
     const names = this._accessor.names;
@@ -158,6 +272,17 @@ export class DataFrame<T extends TypeMap = any> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns DataFrame of Series cast to the new dtype
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Int32, Float32}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new({type: new Int32, data: [0, 1, 1, 2, 2, 2]}),
+   *  b: Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 4]})
+   * })
+   *
+   * df.castAll(new Float32); // returns df with a and b as Float32Series
+   * ```
    */
   castAll<R extends DataType>(dataType: R, memoryResource?: MemoryResource) {
     return new DataFrame(this._accessor.names.reduce(
@@ -171,6 +296,24 @@ export class DataFrame<T extends TypeMap = any> {
    * @param options mapping of column names to sort order specifications
    *
    * @returns Series containting the permutation indices for the desired sort order
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Int32, NullOrder}  from '@rapidsai/cudf';
+   * const df = new DataFrame({a: Series.new([null, 4, 3, 2, 1, 0])});
+   *
+   * df.orderBy({a: {ascending: true, null_order: NullOrder.BEFORE}});
+   * // Int32Series [0, 5, 4, 3, 2, 1]
+   *
+   * df.orderBy({a: {ascending: true, null_order: NullOrder.AFTER}});
+   * // Int32Series [5, 4, 3, 2, 1, 0]
+   *
+   * df.orderBy({a: {ascending: false, null_order: NullOrder.BEFORE}});
+   * // Int32Series [1, 2, 3, 4, 5, 0]
+   *
+   * df.orderBy({a: {ascending: false, null_order: NullOrder.AFTER}});
+   * // Int32Series [0, 1, 2, 3, 4, 5]
+   * ```
    */
   orderBy<R extends keyof T>(options: {[P in R]: OrderSpec}) {
     const column_orders = new Array<boolean>();
@@ -199,6 +342,27 @@ export class DataFrame<T extends TypeMap = any> {
    *   Default: AFTER
    *
    * @returns A new DataFrame of sorted values
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Int32, NullOrder}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *   a: Series.new([null, 4, 3, 2, 1, 0]),
+   *   b: Series.new([0, 1, 2, 3, 4, 5])
+   * });
+   *
+   * df.sortValues({a: {ascending: true, null_order: NullOrder.AFTER}})
+   * // {a: [0, 1, 2, 3, 4, null], b: [5, 4, 3, 2, 1, 0]}
+   *
+   * df.sortValues({a: {ascending: true, null_order: NullOrder.BEFORE}})
+   * // {a: [null, 0, 1, 2, 3, 4], b: [0, 5, 4, 3, 2, 1]}
+   *
+   * df.sortValues({a: {ascending: false, null_order: NullOrder.AFTER}})
+   * // {a: [4, 3, 2, 1, 0, null], b: [1, 2, 3, 4, 5, 0]}
+   *
+   * df.sortValues({a: {ascending: false, null_order: NullOrder.BEFORE}})
+   * // {a: [null, 4, 3, 2, 1, 0], b: [0, 1, 2, 3, 4, 5]}
+   * ```
    */
   sortValues<R extends keyof T>(options: {[P in R]: OrderSpec}) {
     return this.gather(this.orderBy(options));
@@ -208,6 +372,19 @@ export class DataFrame<T extends TypeMap = any> {
    * Return sub-selection from a DataFrame from the specified indices
    *
    * @param selection
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Int32}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *   a: Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 5]}),
+   *   b: Series.new([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+   * });
+   *
+   * const selection = Series.new({type: new Int32, data: [2,4,5]});
+   *
+   * df.gather(selection); // {a: [2, 4, 5], b: [2.0, 4.0, 5.0]}
+   * ```
    */
   gather<R extends IndexType>(selection: Series<R>) {
     const temp       = new Table({columns: this._accessor.columns});
@@ -222,6 +399,19 @@ export class DataFrame<T extends TypeMap = any> {
    * Return a group-by on a single column.
    *
    * @param props configuration for the groupby
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new([0, 1, 1, 2, 2, 2]),
+   *  b: Series.new([0, 1, 2, 3, 4, 4]),
+   *  c: Series.new([1, 2, 3, 4, 5, 6])
+   * })
+   *
+   * df.groupby({by: 'a']}).max() // { a: [2, 1, 0], b: [4, 2, 0], c: [6, 3, 1] }
+   *
+   * ```
    */
   groupBy<R extends keyof T>(props: GroupBySingleProps<T, R>): GroupBySingle<T, R>;
 
@@ -229,6 +419,23 @@ export class DataFrame<T extends TypeMap = any> {
    * Return a group-by on a multiple columns.
    *
    * @param props configuration for the groupby
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new([0, 1, 1, 2, 2, 2]),
+   *  b: Series.new([0, 1, 2, 3, 4, 4]),
+   *  c: Series.new([1, 2, 3, 4, 5, 6])
+   * })
+   *
+   * df.groupby({by: ['a', 'b']}).max()
+   * // {
+   * //   "a_b": [{"a": [2, 1, 1, 2, 0], "b": [4, 2, 1, 3, 0]}],
+   * //   "c": [6, 3, 2, 4, 1]
+   * // }
+   *
+   * ```
    */
   groupBy<R extends keyof T, IndexKey extends string>(props: GroupByMultipleProps<T, R, IndexKey>):
     GroupByMultiple<T, R, IndexKey>;
@@ -250,6 +457,19 @@ export class DataFrame<T extends TypeMap = any> {
    * Return sub-selection from a DataFrame from the specified boolean mask
    *
    * @param mask
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Bool8}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new([0, 1, 2, 3, 4, 4]),
+   *  b: Series.new([0, NaN, 2, 3, 4, 4])
+   * })
+   * const mask = Series.new({type: new Bool8, data: [0, 0, 1, 0, 1, 1]})
+   *
+   * df.filter(mask); // {a: [2, 4, 4], b: [2, 4, 4]}
+   *
+   * ```
    */
   filter(mask: Series<Bool8>) {
     const temp       = new Table({columns: this._accessor.columns});
@@ -280,6 +500,22 @@ export class DataFrame<T extends TypeMap = any> {
 
   /**
    * Copy a Series to an Arrow vector in host memory
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series} from "@rapidsai/cudf";
+   *
+   * const df = new DataFrame({a: Series.new([0,1,2]), b: Series.new(["one", "two", "three"])});
+   *
+   * const arrow_df = df.toArrow(); // Arrow table
+   *
+   * arrow_df.toArray();
+   * // [
+   * //    { "a": 0, "b": "one" },
+   * //    { "a": 1, "b": "two" },
+   * //    { "a": 2, "b": "three" }
+   * //  ]
+   * ```
    */
   toArrow() {
     const toArrowMetadata = (name: string|number, type?: DataType): ToArrowMetadata => {
@@ -406,14 +642,29 @@ export class DataFrame<T extends TypeMap = any> {
    *
    * @example
    * ```typescript
-   * import {DataFrame, Series, Int32, Float32}  from '@rapidsai/cudf';
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
    * const df = new DataFrame({
-   *  "ser_0": Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 4], nullMask: [true,
-   * false, true, true, true, true]}), "ser_1": Series.new({type: new Float32, data: [0,
-   * NaN, 2, 3, 4, 4]})
+   *  a: Series.new([0, null, 2, null, 4, 4]),
+   *  b: Series.new([0, null, 2, 3, null, 4]),
+   *  c: Series.new([null, null, null, null, null, null])
    * });
-   * df.dropNulls(0); // returns df {ser_0: [0,2,3,4,4], ser_1: [0,2,3,4,4]}
-   * df.dropNulls(1); // returns df {ser_1: [0,NaN,2,3,4,4]}
+   *
+   * // delete rows with all nulls (default thresh=1)
+   * df.dropNulls(0);
+   * // return {a: [0, 2, null, 4, 4], b: [0, 2, 3, null, 4], c: [null, null, null, null,
+   * // null]}
+   *
+   * // delete rows with atleast one null
+   * df.dropNulls(0, df.numColumns);
+   * // returns empty df, since each row contains atleast one null
+   *
+   * // delete columns with all nulls (default thresh=1)
+   * df.dropNulls(1);
+   * // returns {a: [0, null, 2, null, 4, 4], b: [0, null, 2, 3, null, 4]}
+   *
+   * // delete columns with atleast one null
+   * df.dropNulls(1, df.numRows);
+   * // returns empty df, since each column contains atleast one null
    *
    * ```
    */
@@ -458,13 +709,29 @@ export class DataFrame<T extends TypeMap = any> {
    *
    * @example
    * ```typescript
-   * import {DataFrame, Series, Int32, Float32}  from '@rapidsai/cudf';
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
    * const df = new DataFrame({
-   *  "ser_0": Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 4]}),
-   *  "ser_1": Series.new({type: new Float32, data: [0, NaN, 2, 3, 4, 4]})
+   *  a: Series.new([0, NaN, 2, NaN, 4, 4]),
+   *  b: Series.new([0, NaN, 2, 3, NaN, 4]),
+   *  c: Series.new([NaN, NaN, NaN, NaN, NaN, NaN])
    * });
-   * df.dropNaNs(0); // returns df {ser_0: [0,2,3,4,4], ser_1: [0,2,3,4,4]}
-   * df.dropNaNs(1); // returns df {ser_0: [0, 1, 2, 3, 4, 4]}
+   *
+   * // delete rows with all NaNs (default thresh=1)
+   * df.dropNaNs(0);
+   * // return {a: [0, 2, NaN, 4, 4], b: [0, 2, 3, NaN, 4], c: [NaN, NaN, NaN, NaN,
+   * // NaN]}
+   *
+   * // delete rows with atleast one NaN
+   * df.dropNaNs(0, df.numColumns);
+   * // returns empty df, since each row contains atleast one NaN
+   *
+   * // delete columns with all NaNs (default thresh=1)
+   * df.dropNaNs(1);
+   * // returns {a: [0, NaN, 2, NaN, 4, 4], b: [0, NaN, 2, 3, NaN, 4]}
+   *
+   * // delete columns with atleast one NaN
+   * df.dropNaNs(1, df.numRows);
+   * // returns empty df, since each column contains atleast one NaN
    *
    * ```
    */
@@ -498,12 +765,12 @@ export class DataFrame<T extends TypeMap = any> {
    * ```typescript
    * import {DataFrame, Series, Int32, Float32}  from '@rapidsai/cudf';
    * const df = new DataFrame({
-   *  "ser_0": Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 4]}),
-   *  "ser_1": Series.new({type: new Float32, data: [0, NaN, 2, 3, 4, 4]})
+   *  a: Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 4]}),
+   *  b: Series.new({type: new Float32, data: [0, NaN, 2, 3, 4, 4]})
    * });
-   * df.get("ser_1").nullCount; // 0
+   * df.get("b").nullCount; // 0
    * const df1 = df.nansToNulls();
-   * df1.get("ser_1").nullCount; // 1
+   * df1.get("b").nullCount; // 1
    *
    * ```
    */

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -259,8 +259,8 @@ export class DataFrame<T extends TypeMap = any> {
    *  b: Series.new({type: new Float32, data: [0, 1, 2, 3, 4, 4]})
    * });
    *
-   * df.get('a') // Int32Series { _col: Column {} }
-   * df.get('b') // Float32Series  { _col: Column {} }
+   * df.get('a') // Int32Series
+   * df.get('b') // Float32Series
    * ```
    */
   get<P extends keyof T>(name: P): Series<T[P]> { return Series.new(this._accessor.get(name)); }
@@ -684,8 +684,10 @@ export class DataFrame<T extends TypeMap = any> {
    *
    * // delete rows with all nulls (default thresh=1)
    * df.dropNulls(0);
-   * // return {a: [0, 2, null, 4, 4], b: [0, 2, 3, null, 4], c: [null, null, null, null,
-   * // null]}
+   * // return {
+   * //   a: [0, 2, null, 4, 4], b: [0, 2, 3, null, 4],
+   * //   c: [null, null, null, null, null]
+   * // }
    *
    * // delete rows with atleast one null
    * df.dropNulls(0, df.numColumns);
@@ -751,8 +753,10 @@ export class DataFrame<T extends TypeMap = any> {
    *
    * // delete rows with all NaNs (default thresh=1)
    * df.dropNaNs(0);
-   * // return {a: [0, 2, NaN, 4, 4], b: [0, 2, 3, NaN, 4], c: [NaN, NaN, NaN, NaN,
-   * // NaN]}
+   * // return {
+   * //    a: [0, 2, NaN, 4, 4], b: [0, 2, 3, NaN, 4],
+   * //    c: [NaN, NaN, NaN, NaN,NaN]
+   * // }
    *
    * // delete rows with atleast one NaN
    * df.dropNaNs(0, df.numColumns);

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -48,6 +48,25 @@ function _seriesToColumns<T extends TypeMap>(data: SeriesMap<T>) {
  * A GPU Dataframe object.
  */
 export class DataFrame<T extends TypeMap = any> {
+  /**
+   * Read a csv from disk and create a cudf.DataFrame
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
+   * const df = DataFrame.readCSV({
+   *  header: 0,
+   *  sourceType: 'files',
+   *  sources: ['test.csv'],
+   *  dataTypes: {
+   *    a: 'int16',
+   *    b: 'bool',
+   *    c: 'float32',
+   *    d: 'str'
+   *  }
+   * })
+   * ```
+   */
   public static readCSV<T extends CSVTypeMap = any>(options: ReadCSVOptions<T>) {
     const {names, table} = Table.readCSV(options);
     return new DataFrame(new ColumnAccessor(

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -442,7 +442,7 @@ export class DataFrame<T extends TypeMap = any> {
    *  c: Series.new([1, 2, 3, 4, 5, 6])
    * })
    *
-   * df.groupby({by: 'a']}).max() // { a: [2, 1, 0], b: [4, 2, 0], c: [6, 3, 1] }
+   * df.groupby({by: 'a'}).max() // { a: [2, 1, 0], b: [4, 2, 0], c: [6, 3, 1] }
    *
    * ```
    */

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -57,6 +57,20 @@ export class DataFrame<T extends TypeMap = any> {
 
   private _accessor: ColumnAccessor<T>;
 
+  /**
+   * Create a new cudf.DataFrame
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new([1, 2]),
+   *  b: Series.new([true, false]),
+   *  c: Series.new(["foo", "bar"])
+   * })
+   *
+   * ```
+   */
   constructor(data: ColumnAccessor<T>|SeriesMap<T>) {
     this._accessor =
       (data instanceof ColumnAccessor) ? data : new ColumnAccessor(_seriesToColumns(data));

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -719,9 +719,9 @@ export {
 };
 
 function inferType(value: any[]): DataType {
-  if (value.length == 0) return new Float64;
+  if (value.length == 0 || (value.every((val) => typeof val === 'number' || val == null)))
+    return new Float64;
   if (value.every((val) => typeof val === 'string' || val == null)) return new Utf8String;
-  if (value.every((val) => typeof val === 'number' || val == null)) return new Float64;
   if (value.every((val) => typeof val === 'bigint' || val == null)) return new Int64;
   if (value.every((val) => typeof val === 'boolean' || val == null)) return new Bool8;
   throw new TypeError('Unable to infer type series type, explicit type declaration expected');

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -604,6 +604,17 @@ export class AbstractSeries<T extends DataType = any> {
    * @param memoryResource Memory resource used to allocate the result Column's device memory.
    * @returns A non-nullable Series of `BOOL8` elements with `true` representing `null`
    *   values.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // Float64Series
+   * Series.new([1, null, 3]).isNull() // [false, true, false]
+   * // StringSeries
+   * Series.new(["foo", "bar", null]).isNull() // [false, false, true]
+   * // Bool8Series
+   * Series.new([true, true, null]).isNull() // [false, false, true]
+   * ```
    */
   isNull(memoryResource?: MemoryResource) { return Series.new(this._col.isNull(memoryResource)); }
 
@@ -614,6 +625,18 @@ export class AbstractSeries<T extends DataType = any> {
    * @param memoryResource Memory resource used to allocate the result Column's device memory.
    * @returns A non-nullable Series of `BOOL8` elements with `false` representing `null`
    *   values.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // Float64Series
+   * Series.new([1, null, 3]).isValid() // [true, false, true]
+   * // StringSeries
+   * Series.new(["foo", "bar", null]).isValid() // [true, true, false]
+   * // Bool8Series
+   * Series.new([true, true, null]).isValid() // [true, true, false]
+   * ```
    */
   isValid(memoryResource?: MemoryResource) { return Series.new(this._col.isValid(memoryResource)); }
 
@@ -621,49 +644,31 @@ export class AbstractSeries<T extends DataType = any> {
    * drop Null values from the series
    * @param memoryResource Memory resource used to allocate the result Column's device memory.
    * @returns series without Null values
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // Float64Series
+   * Series.new([1, undefined, 3]).dropNulls() // [1, 3]
+   * Series.new([1, null, 3]).dropNulls() // [1, 3]
+   * Series.new([1, , 3]).dropNulls() // [1, 3]
+   *
+   * // StringSeries
+   * Series.new(["foo", "bar", undefined]).dropNulls() // ["foo", "bar"]
+   * Series.new(["foo", "bar", null]).dropNulls() // ["foo", "bar"]
+   * Series.new(["foo", "bar", ,]).dropNulls() // ["foo", "bar"]
+   *
+   * // Bool8Series
+   * Series.new([true, true, undefined]).dropNulls() // [true, true]
+   * Series.new([true, true, null]).dropNulls() // [true, true]
+   * Series.new([true, true, ,]).dropNulls() // [true, true]
+   * ```
    */
   dropNulls(memoryResource?: MemoryResource): Series<T> {
     return this.__construct(this._col.drop_nulls(memoryResource));
   }
 
-  /**
-   * Return whether all elements are true in Series.
-   *
-   * @param skipna bool
-   * Exclude null values. If the entire row/column is NA and skipna is true, then the result will
-   * be true, as for an empty row/column. If skipna is false, then NA are treated as true, because
-   * these are not equal to zero.
-   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
-   *   memory.
-   *
-   * @returns true if all elements are true in Series, else false.
-   */
-  all(skipna = true, memoryResource?: MemoryResource) {
-    if (skipna) {
-      if (this.length == this.nullCount) { return true; }
-    }
-    return this._col.all(memoryResource);
-  }
-
-  /**
-   * Return whether any elements are true in Series.
-   *
-   * @param skipna bool
-   * Exclude NA/null values. If the entire row/column is NA and skipna is true, then the result will
-   * be true, as for an empty row/column. If skipna is false, then NA are treated as true, because
-   * these are not equal to zero.
-   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
-   *   memory.
-   *
-   * @returns true if any elements are true in Series, else false.
-   */
-  any(skipna = true, memoryResource?: MemoryResource) {
-    if (this.length == 0) { return false; }
-    if (skipna) {
-      if (this.length == this.nullCount) { return false; }
-    }
-    return this._col.any(memoryResource);
-  }
   /**
    * @summary Hook for specialized Series to override when constructing from a C++ Column.
    */

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -143,11 +143,81 @@ export type Series<T extends arrow.DataType = any> = {
  * One-dimensional GPU array
  */
 export class AbstractSeries<T extends DataType = any> {
+  /**
+   * Create a new cudf.Series from an apache arrow vector
+   *
+   * @example
+   * ```typescript
+   * import {Series, Int32} from '@rapidsai/cudf';
+   * import * as arrow from 'apache-arrow';
+   *
+   * const arrow_vec = arrow.Vector.from({
+   *         type: new Int32,
+   *         values: [1,2,3,4],
+   *         highWaterMark: Infinity
+   *       });
+   * const a = Series.new(arrow_vec); // Int32Series [1, 2, 3, 4]
+   * ```
+   */
   static new<T extends arrow.Vector>(input: T): Series<ArrowToCUDFType<T['type']>>;
+  /**
+   * Create a new cudf.Series from SeriesProps or a cudf.Column
+   *
+   * @example
+   * ```typescript
+   * import {Series, Int32} from '@rapidsai/cudf';
+   *
+   * //using SeriesProps
+   * const a = Series.new({type: new Int32, data: [1, 2, 3, 4]}); // Int32Series [1, 2, 3, 4]
+   *
+   * //using underlying cudf.Column
+   * const b = Series.new(a._col); // Int32Series [1, 2, 3, 4]
+   * ```
+   */
   static new<T extends DataType>(input: Column<T>|SeriesProps<T>): Series<T>;
+  /**
+   * Create a new cudf.StringSeries
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * const a = Series.new(["foo", "bar", "test",null]); // StringSeries ["foo", "bar", "test", null]
+   * ```
+   */
   static new(input: (string|null|undefined)[]): Series<Utf8String>;
+  /**
+   * Create a new cudf.Float64Series
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * const a = Series.new([1, 2, 3,, 4]); // Float64Series [1, 2, 3, null, 4]
+   * ```
+   */
   static new(input: (number|null|undefined)[]): Series<Float64>;
+  /**
+   * Create a new cudf.Int64Series
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * const a = Series.new([1n, 2n, 3n,undefined, 4n]); // Int64Series [1n, 2n, 3n, null, 4n]
+   * ```
+   */
   static new(input: (bigint|null|undefined)[]): Series<Int64>;
+  /**
+   * Create a new cudf.Bool8Series
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * const a = Series.new([true, false, true, false]); // Bool8Series [true, false, true, false]
+   * ```
+   */
   static new(input: (boolean|null|undefined)[]): Series<Bool8>;
   static new<T extends DataType>(input: Column<T>|SeriesProps<T>|arrow.Vector<T>|
                                  (string|null|undefined)[]|(number|null|undefined)[]|

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -157,6 +157,24 @@ export class AbstractSeries<T extends DataType = any> {
    *         highWaterMark: Infinity
    *       });
    * const a = Series.new(arrow_vec); // Int32Series [1, 2, 3, 4]
+   *
+   * const arrow_vec_list = arrow.Vector.from({
+   *   values: [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
+   *   type: new arrow.List(arrow.Field.new({ name: 'ints', type: new arrow.Int32 })),
+   * });
+   *
+   * const b = Series.new(arrow_vec_list) // ListSeries [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+   *
+   * const arrow_vec_struct = arrow.Vector.from({
+   *   values: [{ x: 0, y: 3 }, { x: 1, y: 4 }, { x: 2, y: 5 }],
+   *   type: new arrow.Struct([
+   *     arrow.Field.new({ name: 'x', type: new arrow.Int32 }),
+   *     arrow.Field.new({ name: 'y', type: new arrow.Int32 })
+   *   ]),
+   * });
+   *
+   * const c = Series.new(arrow_vec_struct); // StructSeries  [{ x: 0, y: 3 }, { x: 1, y: 4 },
+   * // { x: 2, y: 5 }]
    * ```
    */
   static new<T extends arrow.Vector>(input: T): Series<ArrowToCUDFType<T['type']>>;

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -214,11 +214,13 @@ export class AbstractSeries<T extends DataType = any> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new([1, 2, 3])
    *
-   * a.fill(0) // [0, 0, 0]
-   * a.fill(0, 1) // [1, 0, 0]
-   * a.fill(0, 0, 1) // [0, 2, 3]
+   * // Float64Series
+   * Series.new([1, 2, 3]).fill(0) // [0, 0, 0]
+   * // StringSeries
+   * Series.new(["foo", "bar", "test"]).fill("rplc", 0, 1) // ["rplc", "bar", "test"]
+   * // Bool8Series
+   * Series.new([true, true, true]).fill(false, 1) // [true, false, false]
    * ```
    */
   fill(value: T, begin = 0, end = this.length, memoryResource?: MemoryResource): Series<T> {
@@ -236,11 +238,13 @@ export class AbstractSeries<T extends DataType = any> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new([1, 2, 3])
    *
-   * a.fillInPlace(0) // [0, 0, 0]
-   * a.fillInPlace(0, 1) // [1, 0, 0]
-   * a.fillInPlace(0, 0, 1) // [0, 2, 3]
+   * // Float64Series
+   * Series.new([1, 2, 3]).fillInPlace(0) // [0, 0, 0]
+   * // StringSeries
+   * Series.new(["foo", "bar", "test"]).fillInPlace("rplc", 0, 1) // ["rplc", "bar", "test"]
+   * // Bool8Series
+   * Series.new([true, true, true]).fillInPlace(false, 1) // [true, false, false]
    * ```
    */
   fillInPlace(value: T, begin = 0, end = this.length) {
@@ -258,9 +262,13 @@ export class AbstractSeries<T extends DataType = any> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new([1, null, 3])
    *
-   * a.replaceNulls(-1) // [1, -1, 3]
+   * // Float64Series
+   * Series.new([1, null, 3]).replaceNulls(-1) // [1, -1, 3]
+   * // StringSeries
+   * Series.new(["foo", "bar", null]).replaceNulls("rplc") // ["foo", "bar", "rplc"]
+   * // Bool8Series
+   * Series.new([null, true, true]).replaceNulls(false) // [true, true, true]
    * ```
    */
   replaceNulls(value: T['scalarType'], memoryResource?: MemoryResource): Series<T>;
@@ -275,10 +283,15 @@ export class AbstractSeries<T extends DataType = any> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new([1, null, 3])
-   * const b = Series.new([1, 5, 3])
+   * const replace = Series.new([10, 10, 10]);
+   * const replaceBool = Series.new([false, false, false]);
    *
-   * a.replaceNulls(b) // [1, 5, 3]
+   * // Float64Series
+   * Series.new([1, null, 3]).replaceNulls(replace) // [1, 10, 3]
+   * // StringSeries
+   * Series.new(["foo", "bar", null]).replaceNulls(replace) // ["foo", "bar", "10"]
+   * // Bool8Series
+   * Series.new([null, true, true]).replaceNulls(replaceBool) // [false, true, true]
    * ```
    */
   replaceNulls(value: Series<T>, memoryResource?: MemoryResource): Series<T>;
@@ -294,10 +307,14 @@ export class AbstractSeries<T extends DataType = any> {
    * @example
    * ```typescript
    * import {Series, ReplacePolicy} from '@rapidsai/cudf';
-   * const a = Series.new({type: @extends {Series<T>}, [1, null, 3])
    *
-   * a.replaceNulls(ReplacePolicy.PRECEDING) // [1, 1, 3]
-   * a.replaceNulls(ReplacePolicy.FOLLOWING) // [1, 3, 3]
+   * // Float64Series
+   * Series.new([1, null, 3]).replaceNulls(ReplacePolicy.PRECEDING) // [1, 1, 3]
+   * // StringSeries
+   * Series.new(["foo", "bar", null]).replaceNulls(ReplacePolicy.PRECEDING) // ["foo", "bar", "bar"]
+   * // Bool8Series
+   * Series.new([null, true, true]).replaceNulls(ReplacePolicy.FOLLOWING) // [true, true, true]
+   *
    * ```
    */
   replaceNulls(value: keyof typeof ReplacePolicy, memoryResource?: MemoryResource): Series<T>;
@@ -325,10 +342,12 @@ export class AbstractSeries<T extends DataType = any> {
    *
    * const a = Series.new([1,2,3]);
    * const b = Series.new(["foo", "bar", "test"]);
+   * const c = Series.new([true, false, true]);
    * const selection = Series.new({type: new Int32, data: [0,2]});
    *
    * a.gather(selection) // Float64Series [1,3]
    * b.gather(selection) // StringSeries ["foo", "test"]
+   * c.gather(selection) // Bool8Series [true, true]
    * ```
    */
   gather<R extends IndexType>(selection: Series<R>): Series<T> {
@@ -349,12 +368,11 @@ export class AbstractSeries<T extends DataType = any> {
    * ```typescript
    * import {Series, Int32} from '@rapidsai/cudf';
    * const a = Series.new({type: new Int32, data: [0, 1, 2, 3, 4]});
-   * const b = Series.new({type: new Int32, data: [200, 400]});
    * const indices = Series.new({type: new Int32, data: [2, 4]});
    * const indices_out_of_bounds = Series.new({type: new Int32, data: [5, 6]});
-   * a.scatter(b, indices); // [0, 1, 200, 3, 400];
    *
-   * a.scatter(b, indices_out_of_bounds, true) // throws index out of bounds error
+   * a.scatter(-1, indices); // [0, 1, -1, 3, -1];
+   * a.scatter(-1, indices_out_of_bounds, true) // throws index out of bounds error
    *
    * ```
    */
@@ -371,6 +389,18 @@ export class AbstractSeries<T extends DataType = any> {
    * @param check_bounds Optionally perform bounds checking on the indices and throw an error if any
    *   of its values are out of bounds (default: false).
    * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
+   *
+   * @example
+   * ```typescript
+   * import {Series, Int32} from '@rapidsai/cudf';
+   * const a = Series.new({type: new Int32, data: [0, 1, 2, 3, 4]});
+   * const b = Series.new({type: new Int32, data: [200, 400]});
+   * const indices = Series.new({type: new Int32, data: [2, 4]});
+   * const indices_out_of_bounds = Series.new({type: new Int32, data: [5, 6]});
+   *
+   * a.scatter(b, indices); // [0, 1, 200, 3, 400];
+   * a.scatter(b, indices_out_of_bounds, true) // throws index out of bounds error
+   * ```
    */
   scatter(values: Series<T>,
           indices: Series<Int32>|number[],
@@ -399,6 +429,19 @@ export class AbstractSeries<T extends DataType = any> {
    *
    * @param mask A Series of boolean values for whose corresponding element in this Series will be
    *   selected or ignored.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from "@rapidsai/cudf";
+   * const mask = Series.new([true, false, true]);
+   *
+   * // Float64Series
+   * Series.new([1, 2, 3]).filter(mask) // [1, 3]
+   * // StringSeries
+   * Series.new(["foo", "bar", "test"]).filter(mask) // ["foo", "test"]
+   * // Bool8Series
+   * Series.new([false, true, true]).filter(mask) // [false, true]
+   * ```
    */
   filter(mask: Series<Bool8>): Series<T> { return this.__construct(this._col.gather(mask._col)); }
 
@@ -406,6 +449,18 @@ export class AbstractSeries<T extends DataType = any> {
    * Return a value at the specified index to host memory
    *
    * @param index the index in this Series to return a value for
+   *
+   * @example
+   * ```typescript
+   * import {Series} from "@rapidsai/cudf";
+   *
+   * // Float64Series
+   * Series.new([1, 2, 3]).getValue(0) // 1
+   * // StringSeries
+   * Series.new(["foo", "bar", "test"]).getValue(2) // "test"
+   * // Bool8Series
+   * Series.new([false, true, true]).getValue(3) // throws index out of bounds error
+   * ```
    */
   getValue(index: number) { return this._col.getValue(index); }
 
@@ -451,6 +506,14 @@ export class AbstractSeries<T extends DataType = any> {
    *
    * @param opts Options for creating the sequence
    * @returns Series with the sequence
+   *
+   * @example
+   * ```typescript
+   * import {Series, Int32, Float32} from '@rapidsai/cudf';
+   *
+   * Series.sequence({type: new Int32, size: 5, init: 0}) // [0, 1, 2, 3, 4]
+   * Series.sequence({type: new Float32, size: 5, step: 2, init: 1}) // [1, 3, 5, 7, 9]
+   * ```
    */
   public static sequence<U extends Numeric>(opts: SequenceOptions<U>): Series<U> {
     const init = new Scalar({type: opts.type, value: opts.init});
@@ -468,6 +531,27 @@ export class AbstractSeries<T extends DataType = any> {
    * @param null_order whether nulls should sort before or after other values
    *
    * @returns Series containting the permutation indices for the desired sort order
+   *
+   * @example
+   * ```typescript
+   * import {Series, NullOrder} from '@rapidsai/cudf';
+   *
+   * // Float64Series
+   * Series.new([50, 40, 30, 20, 10, 0]).orderBy(false) // [0, 1, 2, 3, 4, 5]
+   * Series.new([50, 40, 30, 20, 10, 0]).orderBy(true) // [5, 4, 3, 2, 1, 0]
+   *
+   * // StringSeries
+   * Series.new(["a", "b", "c", "d", "e"]).orderBy(false) // [4, 3, 2, 1, 0]
+   * Series.new(["a", "b", "c", "d", "e"]).orderBy(true) // [0, 1, 2, 3, 4]
+   *
+   * // Bool8Series
+   * Series.new([true, false, true, true, false]).orderBy(true) // [1, 4, 0, 2, 3]
+   * Series.new([true, false, true, true, false]).orderBy(false) // [0, 2, 3, 1, 4]
+   *
+   * // NullOrder usage
+   * Series.new([50, 40, 30, 20, 10, null]).orderBy(false, NullOrder.BEFORE) // [0, 1, 2, 3, 4, 5]
+   * Series.new([50, 40, 30, 20, 10, null]).orderBy(false, NullOrder.AFTER) // [5, 0, 1, 2, 3, 4]
+   * ```
    */
   orderBy(ascending = true, null_order: NullOrder = NullOrder.BEFORE) {
     return Series.new(new Table({columns: [this._col]}).orderBy([ascending], [null_order]));
@@ -482,6 +566,32 @@ export class AbstractSeries<T extends DataType = any> {
    *   Default: BEFORE
    *
    * @returns Sorted values
+   *
+   * @example
+   * ```typescript
+   * import {Series, NullOrder} from '@rapidsai/cudf';
+   *
+   * // Float64Series
+   * Series.new([50, 40, 30, 20, 10, 0]).sortValues(false) // [50, 40, 30, 20, 10, 0]
+   * Series.new([50, 40, 30, 20, 10, 0]).sortValues(true) // [0, 10, 20, 30, 40, 50]
+   *
+   * // StringSeries
+   * Series.new(["a", "b", "c", "d", "e"]).sortValues(false) // ["e", "d", "c", "b", "a"]
+   * Series.new(["a", "b", "c", "d", "e"]).sortValues(true) // ["a", "b", "c", "d", "e"]
+   *
+   * // Bool8Series
+   * Series.new([true, false, true, true, false]).sortValues(true) // [false, false, true, true,
+   * true]
+   * Series.new([true, false, true, true, false]).sortValues(false) // [true, true, true,
+   * false, false]
+   *
+   * // NullOrder usage
+   * Series.new([50, 40, 30, 20, 10, null]).sortValues(false, NullOrder.BEFORE) // [50, 40, 30, 20,
+   * 10, null]
+   *
+   * Series.new([50, 40, 30, 20, 10, null]).sortValues(false, NullOrder.AFTER) // [null, 50, 40, 30,
+   * 20, 10]
+   * ```
    */
   sortValues(ascending = true, null_order: NullOrder = NullOrder.BEFORE): Series<T> {
     return this.gather(this.orderBy(ascending, null_order));

--- a/modules/cudf/src/series/list.ts
+++ b/modules/cudf/src/series/list.ts
@@ -38,12 +38,38 @@ export class ListSeries<T extends DataType> extends Series<List<T>> {
   }
   /**
    * Series of integer offsets for each list
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * import * as arrow from 'apache-arrow';
+   *
+   * const vec = arrow.Vector.from({
+   *   values: [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
+   *   type: new arrow.List(arrow.Field.new({ name: 'ints', type: new arrow.Int32 })),
+   * });
+   * const a = Series.new(vec);
+   *
+   * a.offsets // Int32Series [0, 3, 6, 9]
+   * ```
    */
   // TODO: account for this.offset
   get offsets() { return Series.new(this._col.getChild<Int32>(0)); }
 
   /**
    * Series containing the elements of each list
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * import * as arrow from 'apache-arrow';
+   *
+   * const vec = arrow.Vector.from({
+   *   values: [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
+   *   type: new arrow.List(arrow.Field.new({ name: 'ints', type: new arrow.Int32 })),
+   * });
+   * const a = Series.new(vec);
+   *
+   * a.elements // Int32Series [0, 1, 2, 3, 4, 5, 6, 7, 8]
+   * ```
    */
   // TODO: account for this.offset
   get elements(): Series<T> { return Series.new(this._col.getChild<T>(1)); }

--- a/modules/cudf/src/series/numeric.ts
+++ b/modules/cudf/src/series/numeric.ts
@@ -606,6 +606,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).sin(); // [0, 0.8509035245341184, 0.8414709848078965]
+   * ```
    */
   sin(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.sin(memoryResource));
@@ -617,6 +623,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).cos(); // [1, 0.5253219888177297, 0.5403023058681398]
+   * ```
    */
   cos(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.cos(memoryResource));
@@ -628,6 +640,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).tan(); // [0, 1.6197751905438615, 1.557407724654902]
+   * ```
    */
   tan(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.tan(memoryResource));
@@ -639,6 +657,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).asin(); // [0, NaN, 1.5707963267948966]
+   * ```
    */
   asin(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.asin(memoryResource));
@@ -650,6 +674,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).acos(); // [1.5707963267948966, NaN, 0]
+   * ```
    */
   acos(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.acos(memoryResource));
@@ -661,6 +691,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).atan(); // [0, 1.5485777614681775, 0.7853981633974483]
+   * ```
    */
   atan(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.atan(memoryResource));
@@ -672,6 +708,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).sinh(); // [0, 17467135528742547000, 1.1752011936438014]
+   * ```
    */
   sinh(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.sinh(memoryResource));
@@ -683,6 +725,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).cosh(); // [1, 17467135528742547000, 1.5430806348152437]
+   * ```
    */
   cosh(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.cosh(memoryResource));
@@ -694,6 +742,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).tanh(); // [0, 1, 0.7615941559557649]
+   * ```
    */
   tanh(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.tanh(memoryResource));
@@ -705,6 +759,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, 45, 1]).asinh(); // [0, 4.49993310426429, 0.8813735870195429]
+   * ```
    */
   asinh(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.asinh(memoryResource));
@@ -716,6 +776,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([7, 56, 1]).acosh(); // [2.6339157938496336, 4.71841914237288, 0]
+   * ```
    */
   acosh(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.acosh(memoryResource));
@@ -727,6 +793,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([0, -0.5]).atanh(); // [0, -0.5493061443340549]
+   * ```
    */
   atanh(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.atanh(memoryResource));
@@ -738,6 +810,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([-1.2, 2.5]).exp(); // [0.30119421191220214, 12.182493960703473]
+   * ```
    */
   exp(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.exp(memoryResource));
@@ -749,6 +827,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([-1.2, 2.5, 4]).log(); // [NaN, 0.9162907318741551, 1.3862943611198906]
+   * ```
    */
   log(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.log(memoryResource));
@@ -760,6 +844,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([-1.2, 2.5, 4]).cbrt(); // [NaN, 1.5811388300841898, 2]
+   * ```
    */
   sqrt(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.sqrt(memoryResource));
@@ -771,6 +861,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([-1.2, 2.5]).cbrt(); // [-1.0626585691826111, 1.3572088082974534]
+   * ```
    */
   cbrt(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.cbrt(memoryResource));
@@ -782,6 +878,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([-1.2, 2.5, -3, 4.6, 5]).ceil(); // [-1, 3, -3, 5, 5]
+   * ```
    */
   ceil(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.ceil(memoryResource));
@@ -793,6 +895,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([-1.2, 2.5, -3, 4.6, 5]).floor(); // [-2, 2, -3, 4, 5]
+   * ```
    */
   floor(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.floor(memoryResource));
@@ -804,6 +912,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([-1, 2, -3, 4, 5]).abs(); // [1, 2, 3, 4, 5]
+   * ```
    */
   abs(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.abs(memoryResource));
@@ -815,6 +929,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns A Series of the same number of elements containing the result of the operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([true, false, true, true, false])
+   *
+   * a.not() // [false, true, false, false, true]
    */
   not(memoryResource?: MemoryResource): Series<Bool8> {
     return Series.new(this._col.not(memoryResource));
@@ -831,6 +951,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns The min of all the values in this Column.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([5, 4, 1, 1, 1])
+   *
+   * a.mix() // [1]
    */
   min(skipna = true, memoryResource?: MemoryResource) {
     return this._process_reduction(skipna, memoryResource)._col.min(memoryResource);
@@ -843,6 +969,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns The max of all the values in this Column.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([5, 4, 1, 1, 1])
+   *
+   * a.max() // 5
    */
   max(skipna = true, memoryResource?: MemoryResource) {
     return this._process_reduction(skipna, memoryResource)._col.max(memoryResource);
@@ -855,6 +987,12 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns The pair of [min,max] of all the values in this Column.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([5, 4, 1, 1, 1])
+   *
+   * a.minmax() // [1,5]
    */
   minmax(skipna = true, memoryResource?: MemoryResource) {
     return this._process_reduction(skipna, memoryResource)._col.minmax(memoryResource);
@@ -867,6 +1005,13 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns The sum of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([5, 4, 1, 1, 1])
+   *
+   * a.sum() // 20
+   * ```
    */
   sum(skipna = true, memoryResource?: MemoryResource) {
     return this._process_reduction(skipna, memoryResource)._col.sum(memoryResource);
@@ -880,6 +1025,13 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns The product of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([5, 4, 1, 1, 1])
+   *
+   * a.product() // 20
+   * ```
    */
   product(skipna = true, memoryResource?: MemoryResource) {
     return this._process_reduction(skipna, memoryResource)._col.product(memoryResource);
@@ -893,6 +1045,13 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns The sumOfSquares of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([5, 4, 1, 1, 1])
+   *
+   * a.sumOfSquares() // 44
+   * ```
    */
   sumOfSquares(skipna = true, memoryResource?: MemoryResource) {
     return this._process_reduction(skipna, memoryResource)._col.sum_of_squares(memoryResource);
@@ -906,6 +1065,13 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns The mean of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([5, 4, 1, 1, 1])
+   *
+   * a.mean() // 2.4
+   * ```
    */
   mean(skipna = true, memoryResource?: MemoryResource) {
     if (!skipna && this.nullCount > 0) { return NaN; }
@@ -920,6 +1086,13 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns The median of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([5, 4, 1, 1, 1])
+   *
+   * a.median() // 1
+   * ```
    */
   median(skipna = true, memoryResource?: MemoryResource) {
     if (!skipna && this.nullCount > 0) { return NaN; }
@@ -934,6 +1107,14 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns The number of unqiue values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([1, 2, 3, 4, 4, 5, null, null]);
+   *
+   * a.nunique() // 5
+   * a.nunique(false) // 6
+   * ```
    */
   nunique(dropna = true, memoryResource?: MemoryResource) {
     return this.nullCount === this.length ? dropna ? 0 : 1
@@ -950,6 +1131,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns The unbiased variance of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([1, 2, 3, 4, 5, null]);
+   *
+   * a.var() // 2.5
+   * a.var(true, 2) // 3.333333333333332
+   * a.var(true, 5) // NaN, ddof>=a.length results in NaN
+   * ```
    */
   var(skipna = true, ddof = 1, memoryResource?: MemoryResource) {
     return this._process_reduction(skipna, memoryResource)._col.var(ddof, memoryResource);
@@ -965,6 +1155,17 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns The standard deviation of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * const a = Series.new([1, 2, 3, 4, 5]);
+   *
+   * //skipna=true, ddof=1
+   * a.std() // 1.5811388300841898
+   * a.std(true, 2) // 1.8257418583505534
+   * a.std(true, 5) // NaN, ddof>=a.length results in NaN
+   * ```
    */
   std(skipna = true, ddof = 1, memoryResource?: MemoryResource) {
     return this._process_reduction(skipna, memoryResource)._col.std(ddof, memoryResource);
@@ -980,6 +1181,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns values at the given quantile.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * const a = Series.new([1, 2, 3, 4, 5])
+   *
+   * a.quantile(0.3, "linear") // 2.2
+   * a.quantile(0.3, "lower") // 2
+   * a.quantile(0.3, "higher") // 3
+   * a.quantile(0.3, "midpoint") // 2.5
+   * a.quantile(0.3, "nearest") // 2
+   * ```
    */
   quantile(q                                         = 0.5,
            interpolation: keyof typeof Interpolation = 'linear',
@@ -1003,7 +1216,6 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   *
    * //boolean series
    * Series.new([true, false, true]).all() // false
    * Series.new([true, true, true]).all() // true

--- a/modules/cudf/src/series/numeric.ts
+++ b/modules/cudf/src/series/numeric.ts
@@ -34,6 +34,14 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns Series of same size as the current Series containing result of the `cast` operation.
+   * @example
+   * ```typescript
+   * import {Series, Bool8, Int32} from '@rapidsai/cudf';
+   *
+   * const a = Series.new({type:new Int32, data: [1,0,1,0]});
+   *
+   * a.cast(new Bool8); // Bool8Series [true, false, true, false];
+   * ```
    */
   cast<R extends DataType>(dataType: R, memoryResource?: MemoryResource): Series<R> {
     return Series.new(this._col.cast(dataType, memoryResource));
@@ -77,6 +85,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([10, 12, 14, 20]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.add(3); // [13, 15, 17, 23]
+   * a.add(b); // [13, 14, 15, 23]
+   * ```
    */
   add(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   add(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -100,6 +117,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([10, 12, 14, 20]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.sub(3); // [7, 9, 11, 17]
+   * a.sub(b); // [7, 10, 13, 17]
+   * ```
    */
   sub(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   sub(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -123,6 +149,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([10, 12, 14, 20]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.mul(3); // [30, 36, 42, 60]
+   * a.mul(b); // [30, 24, 14, 60]
+   * ```
    */
   mul(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   mul(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -146,6 +181,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([10, 12, 14, 20]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.div(3); // [3.3333333333333335, 4, 4.666666666666667, 6.666666666666667]
+   * a.div(b); // [3.3333333333333335, 6, 14, 6.666666666666667]
+   * ```
    */
   div(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   div(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -169,6 +213,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([10, 12, 14, 20]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.true_div(3); // [3.3333333333333335, 4, 4.666666666666667, 6.666666666666667]
+   * a.true_div(b); // [3.3333333333333335, 6, 14, 6.666666666666667]
+   * ```
    */
   true_div(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   true_div(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -195,6 +248,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([10, 12, 14, 20]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.floor_div(3); // [ 3, 4, 4, 6 ]
+   * a.floor_div(b); // [ 3, 6, 14, 6 ]
+   * ```
    */
   floor_div(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   floor_div(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -221,6 +283,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([10, 12, 14, 20]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.mod(3); // [ 1, 0, 2, 2 ]
+   * a.mod(b); // [ 1, 0, 0, 2 ]
+   * ```
    */
   mod(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   mod(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -244,6 +315,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([0, 1, 2, 3]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.pow(2); // [ 0, 1, 4, 9 ]
+   * a.pow(b); // [ 0, 1, 2, 27 ]
+   * ```
    */
   pow(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   pow(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -267,6 +347,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of booleans with the comparison result.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([0, 1, 2, 3]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.eq(1); // [ false, true, false, false ]
+   * a.eq(b); // [ false, false, false, true ]
+   * ```
    */
   eq(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   eq(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
@@ -289,6 +378,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of booleans with the comparison result.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([0, 1, 2, 3]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.ne(1); // [true, false, true, true]
+   * a.ne(b); // [true, true, true, false]
+   * ```
    */
   ne(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   ne(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
@@ -311,6 +409,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of booleans with the comparison result.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([0, 1, 2, 3]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.lt(1); // [true, false, false, false]
+   * a.lt(b); // [true, true, false, false]
+   * ```
    */
   lt(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   lt(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
@@ -333,6 +440,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of booleans with the comparison result.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([0, 1, 2, 3]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.le(1); // [true, true, false, false]
+   * a.le(b); // [true, true, false, true]
+   * ```
    */
   le(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   le(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
@@ -355,6 +471,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of booleans with the comparison result.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([0, 1, 2, 3]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.gt(1); // [false, false, true, true]
+   * a.gt(b); // [false, false, true, false]
+   * ```
    */
   gt(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   gt(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
@@ -377,6 +502,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of booleans with the comparison result.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([0, 1, 2, 3]);
+   * const b = Series.new([3, 2, 1, 3]);
+   *
+   * a.ge(1); // [false, true, true, true]
+   * a.ge(b); // [false, false, true, true]
+   * ```
    */
   ge(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   ge(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
@@ -399,6 +533,16 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series, Bool8} from '@rapidsai/cudf';
+   * const a = Series.new([false, true, true, false]);
+   * const b = Series.new([false, false, false, false]);
+   *
+   * a.logical_and(0); // Float64Series [ 0, 0, 0, 0 ]
+   * a.logical_and(0).view(new Bool8); // Bool8Series [ false, false, false, false ]
+   * a.logical_and(b); // [false, false, false, false]
+   * ```
    */
   logical_and(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   logical_and(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -425,6 +569,16 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series, Bool8} from '@rapidsai/cudf';
+   * const a = Series.new([false, true, true, false]);
+   * const b = Series.new([false, false, false, false]);
+   *
+   * a.logical_or(0); // Float64Series [ 0, 1, 1, 0 ]
+   * a.logical_or(0).cast(new Bool8); // Bool8Series [ false, true, true, false ]
+   * a.logical_or(b); // [false, true, true, false]
+   * ```
    */
   logical_or(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   logical_or(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -477,6 +631,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([1, 10, 100]);
+   * const b = Series.new([2, 10, 20]);
+   *
+   * a.log_base(10); // [0, 1, 2]
+   * a.log_base(b); // [0, 1, 1.537243573680482]
+   * ```
    */
   log_base(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   log_base(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -503,6 +666,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([1, 3, 5, null, 7]);
+   * const b = Series.new([1, 3, 3, null, 9]);
+   *
+   * a.atan2(3);
+   * // [0.3217505543966422, 0.7853981633974483, 1.0303768265243125, 0, 1.1659045405098132]
+   *
+   * a.atan2(b);
+   * // [0.7853981633974483, 0.7853981633974483, 1.0303768265243125, 0, 0.6610431688506869]
+   * ```
    */
   atan2(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   atan2(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -530,6 +705,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([1, 3, 5, null, 7]);
+   * const b = Series.new([1, 3, 3, null, 9]);
+   *
+   * a.null_equals(3); // [false, true, false, false, false]
+   * a.null_equals(b); // [true, true, false, true, false]
+   * ```
    */
   null_equals(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   null_equals(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
@@ -555,6 +739,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([1, 3, 5, null, 7]);
+   * const b = Series.new([6, 6, 6, 6, 6]);
+   *
+   * a.null_max(4); // [4, 4, 5, 4, 7]
+   * a.null_max(b); // [6, 6, 6, 6, 7]
+   * ```
    */
   null_max(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   null_max(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -581,6 +774,15 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * @param memoryResource The optional MemoryResource used to allocate the result Column's device
    *   memory.
    * @returns A Series of a common numeric type with the results of the binary operation.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([1, 3, 5, null, 7]);
+   * const c = Series.new([6, 6, 6, 6, 6]);
+   *
+   * a.null_min(4); // [1, 3, 4, 4, 4]
+   * a.null_min(b); // [1, 3, 5, 6, 6]
+   * ```
    */
   null_min(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   null_min(rhs: number, memoryResource?: MemoryResource): Float64Series;
@@ -933,8 +1135,10 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([true, false, true, true, false])
+   * const b = Series.new([0, 1, 2, 3, 4])
    *
    * a.not() // [false, true, false, false, true]
+   * b.not() // [true, false, false, false, false]
    */
   not(memoryResource?: MemoryResource): Series<Bool8> {
     return Series.new(this._col.not(memoryResource));

--- a/modules/cudf/src/series/numeric.ts
+++ b/modules/cudf/src/series/numeric.ts
@@ -1050,7 +1050,7 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
    *
-   * Series.new([-1.2, 2.5, 4]).cbrt(); // [NaN, 1.5811388300841898, 2]
+   * Series.new([-1.2, 2.5, 4]).sqrt(); // [NaN, 1.5811388300841898, 2]
    * ```
    */
   sqrt(memoryResource?: MemoryResource): Series<T> {

--- a/modules/cudf/src/series/numeric.ts
+++ b/modules/cudf/src/series/numeric.ts
@@ -1160,7 +1160,7 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([5, 4, 1, 1, 1])
    *
-   * a.mix() // [1]
+   * a.min() // [1]
    */
   min(skipna = true, memoryResource?: MemoryResource) {
     return this._process_reduction(skipna, memoryResource)._col.min(memoryResource);

--- a/modules/cudf/src/series/numeric.ts
+++ b/modules/cudf/src/series/numeric.ts
@@ -987,4 +987,60 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
     return this._process_reduction(true)._col.quantile(
       q, Interpolation[interpolation], memoryResource);
   }
+
+  /**
+   * Return whether all elements are true in Series.
+   *
+   * @param skipna bool
+   * Exclude null values. If the entire row/column is NA and skipna is true, then the result will
+   * be true, as for an empty row/column. If skipna is false, then NA are treated as true, because
+   * these are not equal to zero.
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   *
+   * @returns true if all elements are true in Series, else false.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * //boolean series
+   * Series.new([true, false, true]).all() // false
+   * Series.new([true, true, true]).all() // true
+   * ```
+   */
+  all(skipna = true, memoryResource?: MemoryResource) {
+    if (skipna) {
+      if (this.length == this.nullCount) { return true; }
+    }
+    return this._col.all(memoryResource);
+  }
+
+  /**
+   * Return whether any elements are true in Series.
+   *
+   * @param skipna bool
+   * Exclude NA/null values. If the entire row/column is NA and skipna is true, then the result will
+   * be true, as for an empty row/column. If skipna is false, then NA are treated as true, because
+   * these are not equal to zero.
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   *
+   * @returns true if any elements are true in Series, else false.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * //boolean series
+   * Series.new([false, false, false]).any() // false
+   * Series.new([true, false, true]).any() // true
+   * ```
+   */
+  any(skipna = true, memoryResource?: MemoryResource) {
+    if (this.length == 0) { return false; }
+    if (skipna) {
+      if (this.length == this.nullCount) { return false; }
+    }
+    return this._col.any(memoryResource);
+  }
 }

--- a/modules/cudf/src/series/string.ts
+++ b/modules/cudf/src/series/string.ts
@@ -37,11 +37,25 @@ export class StringSeries extends Series<Utf8String> {
   }
   /**
    * Series of integer offsets for each string
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new(["foo", "bar"]);
+   *
+   * a.offsets // Int32Array(3) [ 0, 3, 6 ]
+   * ```
    */
   // TODO: Account for this.offset
   get offsets() { return Series.new(this._col.getChild<Int32>(0)); }
   /**
    * Series containing the utf8 characters of each string
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new(["foo", "bar"]);
+   *
+   * a.data // Uint8Array(6) [ 102, 111, 111, 98, 97, 114 ]
+   * ```
    */
   // TODO: Account for this.offset
   get data() { return Series.new(this._col.getChild<Uint8>(1)); }
@@ -58,6 +72,15 @@ export class StringSeries extends Series<Utf8String> {
    * https://docs.rapids.ai/api/libcudf/stable/md_regex.html
    *
    * A RegExp may also be passed, however all flags are ignored (only `pattern.source` is used)
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new(["foo", "bar"]);
+   *
+   * a.containsRe(/fo/ig) // [true, false]
+   * a.containsRe('foo') // [true, false]
+   * ```
    */
   containsRe(pattern: string|RegExp, memoryResource?: MemoryResource): Series<Bool8> {
     const pat_string = pattern instanceof RegExp ? pattern.source : pattern;
@@ -77,6 +100,15 @@ export class StringSeries extends Series<Utf8String> {
    * https://docs.rapids.ai/api/libcudf/stable/md_regex.html
    *
    * A RegExp may also be passed, however all flags are ignored (only `pattern.source` is used)
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new(["foo_fo", "bar"]);
+   *
+   * a.countRe(/o/ig) // [3, 0]
+   * a.countRe('fo') // [2, 0]
+   * ```
    */
   countRe(pattern: string|RegExp, memoryResource?: MemoryResource): Series<Int32> {
     const pat_string = pattern instanceof RegExp ? pattern.source : pattern;
@@ -96,6 +128,15 @@ export class StringSeries extends Series<Utf8String> {
    * https://docs.rapids.ai/api/libcudf/stable/md_regex.html
    *
    * A RegExp may also be passed, however all flags are ignored (only `pattern.source` is used)
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new(["foo_bar", "bar_foo"]);
+   *
+   * a.matchesRe(/foo/ig) // [true, false]
+   * a.matchesRe('bar') // [false, true]
+   * ```
    */
   matchesRe(pattern: string|RegExp, memoryResource?: MemoryResource): Series<Bool8> {
     const pat_string = pattern instanceof RegExp ? pattern.source : pattern;

--- a/modules/cudf/src/series/string.ts
+++ b/modules/cudf/src/series/string.ts
@@ -76,10 +76,16 @@ export class StringSeries extends Series<Utf8String> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new(["foo", "bar"]);
+   * const a = Series.new(['Finland','Colombia','Florida', 'Russia','france']);
    *
-   * a.containsRe(/fo/ig) // [true, false]
-   * a.containsRe('foo') // [true, false]
+   * // items starting with F (only upper case)
+   * a.containsRe(/^F/) // [true, false, true, false, false]
+   * // items starting with F or f
+   * a.containsRe(/^[Ff]/) // [true, false, true, false, true]
+   * // items ending with a
+   * a.containsRe("a$") // [false, true, true, true, false]
+   * // items containing "us"
+   * a.containsRe("us") // [false, false, false, true, false]
    * ```
    */
   containsRe(pattern: string|RegExp, memoryResource?: MemoryResource): Series<Bool8> {
@@ -104,10 +110,15 @@ export class StringSeries extends Series<Utf8String> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new(["foo_fo", "bar"]);
+   * const a = Series.new(['Finland','Colombia','Florida', 'Russia','france']);
    *
-   * a.countRe(/o/ig) // [3, 0]
-   * a.countRe('fo') // [2, 0]
+   * // count occurences of "o"
+   * a.countRe(/o/) // [0, 2, 1, 0, 0]
+   * // count occurences of "an"
+   * a.countRe('an') // [1, 0, 0, 0, 1]
+   *
+   * // get number of countries starting with F or f
+   * a.countRe(/^[fF]).count() // 3
    * ```
    */
   countRe(pattern: string|RegExp, memoryResource?: MemoryResource): Series<Int32> {
@@ -132,10 +143,12 @@ export class StringSeries extends Series<Utf8String> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new(["foo_bar", "bar_foo"]);
+   * const a = Series.new(['Finland','Colombia','Florida', 'Russia','france']);
    *
-   * a.matchesRe(/foo/ig) // [true, false]
-   * a.matchesRe('bar') // [false, true]
+   * // start of item contains "C"
+   * a.matchesRe(/C/) // [false, true, false, false, false]
+   * // start of item contains "us", returns false since none of the items start with "us"
+   * a.matchesRe('us') // [false, false, false, false, false]
    * ```
    */
   matchesRe(pattern: string|RegExp, memoryResource?: MemoryResource): Series<Bool8> {

--- a/modules/cudf/src/series/struct.ts
+++ b/modules/cudf/src/series/struct.ts
@@ -41,6 +41,24 @@ export class StructSeries<T extends TypeMap> extends Series<Struct<T>> {
    * Return a child series by name.
    *
    * @param name Name of the Series to return.
+   *
+   * @example
+   * ```typescript
+   * import {Series} = require('@rapidsai/cudf');
+   * import * as arrow from 'apache-arrow';
+   *
+   * const vec = arrow.Vector.from({
+   *   values: [{ x: 0, y: 3 }, { x: 1, y: 4 }, { x: 2, y: 5 }],
+   *   type: new arrow.Struct([
+   *     arrow.Field.new({ name: 'x', type: new arrow.Int32 }),
+   *     arrow.Field.new({ name: 'y', type: new arrow.Int32 })
+   *   ]),
+   * });
+   * const a = Series.new(vec);
+   *
+   * a.getChild('x') // Int32Series [0, 1, 2]
+   * a.getChild('y') // Int32Series [3, 4, 5]
+   * ```
    */
   // TODO: Account for this.offset
   getChild<P extends keyof T>(name: P): Series<T[P]> {


### PR DESCRIPTION
This PR aims to add code snippets in the docstrings for dataframe and series functions, as requested in #109.

EDIT: Minor refactor for `all` and `any` aggregations -> moved them to `numeric.ts` from `series.ts` since StringSeries do not support the methods, and throw a cudf::logic error