### PR TITLE
[CI] Install llnode into the devel container, remove it from package.json

### DIFF
--- a/dockerfiles/devel.Dockerfile
+++ b/dockerfiles/devel.Dockerfile
@@ -148,7 +148,9 @@ export HISTFILE=\"\$DOCKER_WORKDIR/modules/.cache/.eternal_bash_history\";\n\
  # add yarn completions
  && curl -fsSL --compressed \
     https://raw.githubusercontent.com/dsifford/yarn-completion/5bf2968493a7a76649606595cfca880a77e6ac0e/yarn-completion.bash \
-  | tee /etc/bash_completion.d/yarn >/dev/null
+  | tee /etc/bash_completion.d/yarn >/dev/null \
+ # globally install llnode
+ && yarn global add github:trxcllnt/llnode#use-llvm-project-monorepo
 
 # avoid "OSError: library nvvm not found" error
 ENV CUDA_HOME="/usr/local/cuda"

--- a/dockerfiles/devel.Dockerfile
+++ b/dockerfiles/devel.Dockerfile
@@ -124,6 +124,7 @@ RUN useradd --uid $UID --user-group ${ADDITIONAL_GROUPS} --shell /bin/bash --cre
  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
  && ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
  && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+ && npm install -g npm \
  # smoke tests
  && node --version && npm --version && yarn --version \
  && sed -ri "s/32m/33m/g" /home/node/.bashrc \
@@ -150,7 +151,9 @@ export HISTFILE=\"\$DOCKER_WORKDIR/modules/.cache/.eternal_bash_history\";\n\
     https://raw.githubusercontent.com/dsifford/yarn-completion/5bf2968493a7a76649606595cfca880a77e6ac0e/yarn-completion.bash \
   | tee /etc/bash_completion.d/yarn >/dev/null \
  # globally install llnode
- && yarn global add github:trxcllnt/llnode#use-llvm-project-monorepo
+ && git clone --branch use-llvm-project-monorepo https://github.com/trxcllnt/llnode.git /usr/local/lib/llnode \
+ && npm install --global --unsafe-perm --no-audit --no-fund /usr/local/lib/llnode \
+ && which -a llnode
 
 # avoid "OSError: library nvvm not found" error
 ENV CUDA_HOME="/usr/local/cuda"

--- a/dockerfiles/nteract.Dockerfile
+++ b/dockerfiles/nteract.Dockerfile
@@ -57,7 +57,7 @@ if __name__ == \"__main__\":\n\
  && apt autoremove -y \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
  # Install ijavascript
- && npm install -g --unsafe-perm ijavascript \
+ && npm install --global --unsafe-perm --no-audit --no-fund ijavascript \
  && ijsinstall --install=global --spec-path=full
 
 USER node

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint": "7.22.0",
     "lerna": "3.22.1",
     "lint-staged": "10.5.1",
-    "llnode": "git://github.com/trxcllnt/llnode.git#use-llvm-project-monorepo",
     "node-addon-api": "^3.1.0",
     "pre-git": "3.17.1",
     "rimraf": "3.0.0",


### PR DESCRIPTION
Having `llnode` in our package.json entry is causing the CI docs builder to fail installing packages because it needs `lldb`. This moves llnode installation into the `devel` container's build instead.