### PR TITLE
Add series isnull binding

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -58,8 +58,8 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `head`               |                     |
 | `interleave_columns` |                     |
 | `isin`               |                     |
-| `isna`               |                     |
-| `isnull`             |                     |
+| `isna`               |    ✅ (`isNull`)    |
+| `isnull`             |         ✅          |
 | `keys`               |                     |
 | `kurt`               |                     |
 | `kurtosis`           |                     |
@@ -175,8 +175,8 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `head`               |                     |                     |                     |
 | `interleave_columns` |                     |                     |                     |
 | `isin`               |                     |                     |                     |
-| `isna`               |                     |                     |                     |
-| `isnull`             |                     |                     |                     |
+| `isna`               |    ✅ (`isNull`)    |    ✅ (`isNull`)    |    ✅ (`isNull`)    |
+| `isnull`             |         ✅          |         ✅          |         ✅          |
 | `keys`               |                     |                     |                     |
 | `kurt`               |                     |                     |                     |
 | `kurtosis`           |                     |                     |                     |

--- a/modules/cudf/src/series/float.ts
+++ b/modules/cudf/src/series/float.ts
@@ -45,7 +45,7 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
   /**
    * Creates a Series of `BOOL8` elements indicating the absence of `NaN` values in a
    * column of floating point values. The output element at row `i` is `false` if the element in
-   * `input` at row i is `NAN`, else `true`
+   * `input` at row i is `NaN`, else `true`
    *
    * @param memoryResource Memory resource used to allocate the result Series's device memory.
    * @returns A non-nullable Series of `BOOL8` elements with `true` representing `NAN`

--- a/modules/cudf/src/series/float.ts
+++ b/modules/cudf/src/series/float.ts
@@ -27,23 +27,28 @@ import {NumericSeries} from './numeric';
  */
 abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
   /**
-   * Creates a column of `BOOL8` elements indicating the presence of `NaN` values in a
-   * column of floating point values. The output element at row `i` is `true` if the element in
-   * `input` at row i is `NAN`, else `false`
+   * Creates a Series of `BOOL8` elements where `true` indicates the value is `NaN` and `false`
+   * indicates the value is valid.
    *
-   * @param memoryResource Memory resource used to allocate the result Series's device memory.
-   * @returns A non-nullable column of `BOOL8` elements with `true` representing `NAN`
-   *   values
+   * @param memoryResource Memory resource used to allocate the result Column's device memory.
+   * @returns A non-nullable Series of `BOOL8` elements with `true` representing `NaN` values.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // Float64Series
+   * Series.new([1, NaN, 3]).isNaN() // [false, true, false]
+   * ```
    */
   isNaN(memoryResource?: MemoryResource) { return Series.new(this._col.isNaN(memoryResource)); }
 
   /**
-   * Creates a column of `BOOL8` elements indicating the absence of `NaN` values in a
+   * Creates a Series of `BOOL8` elements indicating the absence of `NaN` values in a
    * column of floating point values. The output element at row `i` is `false` if the element in
    * `input` at row i is `NAN`, else `true`
    *
    * @param memoryResource Memory resource used to allocate the result Series's device memory.
-   * @returns A non-nullable column of `BOOL8` elements with `true` representing `NAN`
+   * @returns A non-nullable Series of `BOOL8` elements with `true` representing `NAN`
    *   values
    */
   isNotNaN(memoryResource?: MemoryResource) {

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -324,6 +324,14 @@ test('Series.sortValues (descending)', () => {
   expect([...result.toArrow()]).toEqual(expected);
 });
 
+test('Series.isNull (numeric)', () => {
+  const col    = Series.new({type: new Int32, data: [0, 1, null, 3, 4, null, 6, null]});
+  const result = col.isNull();
+
+  const expected = [false, false, true, false, false, true, false, true];
+  expect([...result.toArrow()]).toEqual(expected);
+});
+
 test('Series.dropNulls (drop nulls only)', () => {
   const mask = new Uint8Buffer(BoolVector.from([0, 1, 1, 1, 1, 0]).values);
   const col =

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -329,7 +329,7 @@ test('Series.isNull (numeric)', () => {
   const result = col.isNull();
 
   const expected = [false, false, true, false, false, true, false, true];
-  expect([...result.toArrow()]).toEqual(expected);
+  expect([...result]).toEqual(expected);
 });
 
 test('Series.dropNulls (drop nulls only)', () => {


### PR DESCRIPTION
First basic PR to get my bearings :tada:

**Changes**
- Update `BINDINGS.md` to include `isNull` (already existing binding)
- Correct `float.ts` documentation from columns to series
- Add a `isNull` test to `cudf-series-test.ts`

**Unsure**
- `isNaN` is only available for floating point types, so I marked any instances of `isna` inside of `BINDINGS.md` to just use `isNull`.