### PR TITLE
Clean up tests to use spread enumeration

### DIFF
--- a/modules/cudf/test/cudf-column-tests.ts
+++ b/modules/cudf/test/cudf-column-tests.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ test('Column.drop_nans', () => {
   const result = col.drop_nans();
 
   const expected = [1, 3, 4, 2, 0];
-  expect([...Series.new(result).toArrow()]).toEqual(expected);
+  expect([...Series.new(result)]).toEqual(expected);
 });
 
 test('Column.drop_nulls', () => {
@@ -132,7 +132,7 @@ test('Column.drop_nulls', () => {
   const result = col.drop_nulls();
 
   const expected = [3, NaN, 4, 2];
-  expect([...Series.new(result).toArrow()]).toEqual(expected);
+  expect([...Series.new(result)]).toEqual(expected);
 });
 
 test('Column.nans_to_nulls', () => {
@@ -141,5 +141,5 @@ test('Column.nans_to_nulls', () => {
   const result = col.nans_to_nulls();
 
   const expected = [1, 3, null, 4, 2, 0];
-  expect([...Series.new(result).toArrow()]).toEqual(expected);
+  expect([...Series.new(result)]).toEqual(expected);
 });

--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -155,7 +155,7 @@ test('DataFrame.orderBy (ascending, non-null)', () => {
   const result = df.orderBy({'a': {ascending: true, null_order: NullOrder.BEFORE}});
 
   const expected = [5, 0, 4, 1, 3, 2];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual([...Buffer.from(expected)]);
 });
 
 test('DataFrame.orderBy (descending, non-null)', () => {
@@ -164,7 +164,7 @@ test('DataFrame.orderBy (descending, non-null)', () => {
   const result = df.orderBy({'a': {ascending: false, null_order: NullOrder.BEFORE}});
 
   const expected = [2, 3, 1, 4, 0, 5];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual([...Buffer.from(expected)]);
 });
 
 test('DataFrame.orderBy (ascending, null before)', () => {
@@ -175,7 +175,7 @@ test('DataFrame.orderBy (ascending, null before)', () => {
   const result = df.orderBy({'a': {ascending: true, null_order: NullOrder.BEFORE}});
 
   const expected = [1, 5, 0, 4, 3, 2];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual([...Buffer.from(expected)]);
 });
 
 test('DataFrame.orderBy (ascending, null after)', () => {
@@ -186,7 +186,7 @@ test('DataFrame.orderBy (ascending, null after)', () => {
   const result = df.orderBy({'a': {ascending: true, null_order: NullOrder.AFTER}});
 
   const expected = [5, 0, 4, 3, 2, 1];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual([...Buffer.from(expected)]);
 });
 
 test('DataFrame.orderBy (descendng, null before)', () => {
@@ -198,7 +198,7 @@ test('DataFrame.orderBy (descendng, null before)', () => {
 
   const expected = [2, 3, 4, 0, 5, 1];
 
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual([...Buffer.from(expected)]);
 });
 
 test('DataFrame.orderBy (descending, null after)', () => {
@@ -209,7 +209,7 @@ test('DataFrame.orderBy (descending, null after)', () => {
   const result = df.orderBy({'a': {ascending: false, null_order: NullOrder.AFTER}});
 
   const expected = [1, 2, 3, 4, 0, 5];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual([...Buffer.from(expected)]);
 });
 
 test('DataFrame.gather (indices)', () => {
@@ -227,10 +227,10 @@ test('DataFrame.gather (indices)', () => {
   const rb = result.get('b');
 
   const expected_a = Series.new({type: new Int32(), data: new Int32Buffer([2, 4, 5])});
-  expect([...ra.toArrow()]).toEqual([...expected_a.toArrow()]);
+  expect([...ra]).toEqual([...expected_a]);
 
   const expected_b = Series.new({type: new Float32(), data: new Float32Buffer([2.0, 4.0, 5.0])});
-  expect([...rb.toArrow()]).toEqual([...expected_b.toArrow()]);
+  expect([...rb]).toEqual([...expected_b]);
 });
 
 test('DataFrame groupBy (single)', () => {
@@ -266,10 +266,10 @@ test('DataFrame filter', () => {
   const rb = result.get('b');
 
   const expected_a = Series.new({type: new Int32(), data: new Int32Buffer([2, 4, 5])});
-  expect([...ra.toArrow()]).toEqual([...expected_a.toArrow()]);
+  expect([...ra]).toEqual([...expected_a]);
 
   const expected_b = Series.new({type: new Float32(), data: new Float32Buffer([2.0, 4.0, 5.0])});
-  expect([...rb.toArrow()]).toEqual([...expected_b.toArrow()]);
+  expect([...rb]).toEqual([...expected_b]);
 });
 
 test(
@@ -319,8 +319,8 @@ test(
     const ra     = result.get('a');
     const rc     = result.get('c');
 
-    expect([...ra.toArrow()]).toEqual([...expected_a.toArrow()]);
-    expect([...rc.toArrow()]).toEqual([...expected_c.toArrow()]);
+    expect([...ra]).toEqual([...expected_a]);
+    expect([...rc]).toEqual([...expected_c]);
     expect(result.numRows).toEqual(5);
   });
 
@@ -391,7 +391,7 @@ test('dataframe.dropNaNs(axis=0, thresh=1), drop row with non-NaN values < 1 (dr
        const result = df.dropNaNs(0, 1);
        const ra     = result.get('a');
 
-       expect([...ra.toArrow()]).toEqual([...expected_a.toArrow()]);
+       expect([...ra]).toEqual([...expected_a]);
        expect(result.numRows).toEqual(5);
      });
 

--- a/modules/cudf/test/cudf-groupby-tests.ts
+++ b/modules/cudf/test/cudf-groupby-tests.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 // Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import './jest-extensions';
 
@@ -46,7 +47,7 @@ function basicAggCompare<T extends {a: DataType, b: DataType, c: DataType}>(
   const rc = result.get('c');
 
   const a_expected = Series.new({type: new Int32, data: [1, 2, 3]});
-  expect([...ra.toArrow()]).toEqual([...a_expected.toArrow()]);
+  expect([...ra]).toEqual([...a_expected]);
 
   const b_expected = Series.new({type: rb.type, data: expected});
   expect(rb.toArrow().toArray()).toEqualTypedArray(b_expected.toArrow().toArray() as any);
@@ -62,7 +63,7 @@ test('getGroups basic', () => {
   const groups = grp.getGroups();
 
   const keys_result = groups['keys'].get('a');
-  expect([...keys_result.toArrow()]).toEqual([1, 1, 1, 2, 2, 3]);
+  expect([...keys_result]).toEqual([1, 1, 1, 2, 2, 3]);
 
   expect(groups.values).toBeUndefined();
 
@@ -79,10 +80,10 @@ test('getGroups basic two columns', () => {
   const groups = grp.getGroups();
 
   const keys_result_a = groups['keys'].get('a');
-  expect([...keys_result_a.toArrow()]).toEqual([1, 1, 1, 2, 2, 3]);
+  expect([...keys_result_a]).toEqual([1, 1, 1, 2, 2, 3]);
 
   const keys_result_aa = groups['keys'].get('aa');
-  expect([...keys_result_aa.toArrow()]).toEqual([4, 4, 5, 4, 4, 3]);
+  expect([...keys_result_aa]).toEqual([4, 4, 5, 4, 4, 3]);
 
   expect(groups.values).toBeUndefined();
 
@@ -116,17 +117,17 @@ test('getGroups basic with values', () => {
   const groups = grp.getGroups();
 
   const keys_result = groups['keys'].get('a');
-  expect([...keys_result.toArrow()]).toEqual([0, 1, 2, 3, 4, 5]);
+  expect([...keys_result]).toEqual([0, 1, 2, 3, 4, 5]);
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
   const values_result_b = groups.values?.get('b')!;
   expect(values_result_b).toBeDefined();
-  expect([...values_result_b.toArrow()]).toEqual([2, 2, 1, 1, 0, 0]);
+  expect([...values_result_b]).toEqual([2, 2, 1, 1, 0, 0]);
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
   const values_result_c = groups.values?.get('c')!;
   expect(values_result_c).toBeDefined();
-  expect([...values_result_c.toArrow()]).toEqual([2, 2, 1, 1, 0, 0]);
+  expect([...values_result_c]).toEqual([2, 2, 1, 1, 0, 0]);
 
   expect([...groups['offsets']]).toEqual([0, 1, 2, 3, 4, 5, 6]);
 });
@@ -143,20 +144,20 @@ test('getGroups basic two columns with values', () => {
   const groups = grp.getGroups();
 
   const keys_result_a = groups['keys'].get('a');
-  expect([...keys_result_a.toArrow()]).toEqual([0, 1, 2, 3, 4, 5]);
+  expect([...keys_result_a]).toEqual([0, 1, 2, 3, 4, 5]);
 
   const keys_result_aa = groups['keys'].get('aa');
-  expect([...keys_result_aa.toArrow()]).toEqual([3, 4, 4, 4, 5, 4]);
+  expect([...keys_result_aa]).toEqual([3, 4, 4, 4, 5, 4]);
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
   const values_result_b = groups.values?.get('b')!;
   expect(values_result_b).toBeDefined();
-  expect([...values_result_b.toArrow()]).toEqual([2, 2, 1, 1, 0, 0]);
+  expect([...values_result_b]).toEqual([2, 2, 1, 1, 0, 0]);
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
   const values_result_c = groups.values?.get('c')!;
   expect(values_result_c).toBeDefined();
-  expect([...values_result_c.toArrow()]).toEqual([2, 2, 1, 1, 0, 0]);
+  expect([...values_result_c]).toEqual([2, 2, 1, 1, 0, 0]);
 
   expect([...groups['offsets']]).toEqual([0, 1, 2, 3, 4, 5, 6]);
 });
@@ -188,18 +189,18 @@ test('getGroups some nulls', () => {
   const groups = grp.getGroups();
 
   const keys_result = groups['keys'].get('a');
-  expect([...keys_result.toArrow()]).toEqual([1, 2, 3]);
+  expect([...keys_result]).toEqual([1, 2, 3]);
   expect(keys_result.nullCount).toBe(0);
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
   const values_result_b = groups.values?.get('b')!;
   expect(values_result_b).toBeDefined();
-  expect([...values_result_b.toArrow()]).toEqual([1, 6, 3]);
+  expect([...values_result_b]).toEqual([1, 6, 3]);
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
   const values_result_c = groups.values?.get('c')!;
   expect(values_result_c).toBeDefined();
-  expect([...values_result_c.toArrow()]).toEqual([1, 6, 3]);
+  expect([...values_result_c]).toEqual([1, 6, 3]);
 
   expect([...groups['offsets']]).toEqual([0, 1, 2, 3]);
 });
@@ -220,7 +221,7 @@ test('aggregation column name with two columns', () => {
   const keys_result_aa = result_out.getChild('aa');
 
   const sorter = [0, 1, 2, 3, 4, 5];
-  const ka     = [...keys_result_a.toArrow()];
+  const ka     = [...keys_result_a];
   sorter.sort((i, j) => ka[i]! - ka[j]!);
 
   const sorted_a =
@@ -435,7 +436,7 @@ for (const agg of BASIC_AGGS) {
     const df     = new DataFrame({a, b, c});
     const grp    = new GroupBySingle(df, {by: 'a'});
     const result = grp[agg]();
-    expect([...result.get('a').toArrow()]).toEqual([1]);
+    expect([...result.get('a')]).toEqual([1]);
     expect(result.get('a').nullCount).toBe(0);
     expect(result.get('b').length).toBe(1);
     expect(result.get('c').length).toBe(1);
@@ -456,7 +457,7 @@ test(`Groupby nth null values`, () => {
   const df     = new DataFrame({a, b, c});
   const grp    = new GroupBySingle(df, {by: 'a'});
   const result = grp.nth(0);
-  expect([...result.get('a').toArrow()]).toEqual([1]);
+  expect([...result.get('a')]).toEqual([1]);
   expect(result.get('a').nullCount).toBe(0);
   expect(result.get('b').length).toBe(1);
   expect(result.get('b').nullCount).toBe(1);
@@ -471,7 +472,7 @@ test(`Groupby quantile null values`, () => {
   const df     = new DataFrame({a, b, c});
   const grp    = new GroupBySingle(df, {by: 'a'});
   const result = grp.quantile(0.5);
-  expect([...result.get('a').toArrow()]).toEqual([1]);
+  expect([...result.get('a')]).toEqual([1]);
   expect(result.get('a').nullCount).toBe(0);
   expect(result.get('b').length).toBe(1);
   expect(result.get('b').nullCount).toBe(1);

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ test('Series.gather', () => {
 
   const result = col.gather(selection);
 
-  expect([...result.toArrow()]).toEqual([...selection.toArrow()]);
+  expect([...result]).toEqual([...selection]);
 });
 
 test('Series.scatter (series)', () => {
@@ -226,7 +226,7 @@ test('Series.filter', () => {
   const result = col.filter(mask);
 
   const expected = Series.new({type: new Int32, data: new Int32Buffer([2, 4, 5, 8])});
-  expect([...result.toArrow()]).toEqual([...expected.toArrow()]);
+  expect([...result]).toEqual([...expected]);
 });
 
 describe('toArrow()', () => {
@@ -256,7 +256,7 @@ test('Series.orderBy (ascending, non-null)', () => {
   const result = col.orderBy(true, NullOrder.BEFORE);
 
   const expected = [5, 0, 4, 1, 3, 2];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual(expected);
 });
 
 test('Series.orderBy (descending, non-null)', () => {
@@ -264,7 +264,7 @@ test('Series.orderBy (descending, non-null)', () => {
   const result = col.orderBy(false, NullOrder.BEFORE);
 
   const expected = [2, 3, 1, 4, 0, 5];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual(expected);
 });
 
 test('Series.orderBy (ascending, null before)', () => {
@@ -274,7 +274,7 @@ test('Series.orderBy (ascending, null before)', () => {
   const result = col.orderBy(true, NullOrder.BEFORE);
 
   const expected = [1, 5, 0, 4, 3, 2];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual(expected);
 });
 
 test('Series.orderBy (ascending, null after)', () => {
@@ -284,7 +284,7 @@ test('Series.orderBy (ascending, null after)', () => {
   const result = col.orderBy(true, NullOrder.AFTER);
 
   const expected = [5, 0, 4, 3, 2, 1];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual(expected);
 });
 
 test('Series.orderBy (descendng, null before)', () => {
@@ -295,7 +295,7 @@ test('Series.orderBy (descendng, null before)', () => {
 
   const expected = [2, 3, 4, 0, 5, 1];
 
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual(expected);
 });
 
 test('Series.orderBy (descending, null after)', () => {
@@ -305,7 +305,7 @@ test('Series.orderBy (descending, null after)', () => {
   const result = col.orderBy(false, NullOrder.AFTER);
 
   const expected = [1, 2, 3, 4, 0, 5];
-  expect([...result.toArrow()]).toEqual([...Buffer.from(expected)]);
+  expect([...result]).toEqual(expected);
 });
 
 test('Series.sortValues (ascending)', () => {
@@ -313,7 +313,7 @@ test('Series.sortValues (ascending)', () => {
   const result = col.sortValues();
 
   const expected = [0, 1, 2, 3, 4, 5];
-  expect([...result.toArrow()]).toEqual(expected);
+  expect([...result]).toEqual(expected);
 });
 
 test('Series.sortValues (descending)', () => {
@@ -321,7 +321,7 @@ test('Series.sortValues (descending)', () => {
   const result = col.sortValues(false);
 
   const expected = [5, 4, 3, 2, 1, 0];
-  expect([...result.toArrow()]).toEqual(expected);
+  expect([...result]).toEqual(expected);
 });
 
 test('Series.dropNulls (drop nulls only)', () => {
@@ -331,7 +331,7 @@ test('Series.dropNulls (drop nulls only)', () => {
   const result = col.dropNulls();
 
   const expected = [3, NaN, 4, 2];
-  expect([...result.toArrow()]).toEqual(expected);
+  expect([...result]).toEqual(expected);
 });
 
 test('FloatSeries.dropNaNs (drop NaN values only)', () => {
@@ -341,7 +341,7 @@ test('FloatSeries.dropNaNs (drop NaN values only)', () => {
   const result = col.dropNaNs();
 
   const expected = [null, 3, 4, 2, null];
-  expect([...result.toArrow()]).toEqual(expected);
+  expect([...result]).toEqual(expected);
 });
 
 test('FloatSeries.nansToNulls', () => {
@@ -350,7 +350,7 @@ test('FloatSeries.nansToNulls', () => {
   const result = col.nansToNulls();
 
   const expected = [1, 3, null, 4, 2, 0];
-  expect([...result.toArrow()]).toEqual(expected);
+  expect([...result]).toEqual(expected);
   expect(result.nullCount).toEqual(1);
   expect(col.nullCount).toEqual(0);
 });
@@ -358,23 +358,23 @@ test('FloatSeries.nansToNulls', () => {
 describe.each([new Int32, new Float32, new Float64])('Series.sequence({type=%p,, ...})', (typ) => {
   test('no step', () => {
     const col = Series.sequence({type: typ, size: 10, init: 0});
-    expect([...col.toArrow()]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect([...col]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
   test('step=1', () => {
     const col = Series.sequence({type: typ, size: 10, step: 1, init: 0});
-    expect([...col.toArrow()]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect([...col]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
   test('step=2', () => {
     const col = Series.sequence({type: typ, size: 10, step: 2, init: 0});
-    expect([...col.toArrow()]).toEqual([0, 2, 4, 6, 8, 10, 12, 14, 16, 18]);
+    expect([...col]).toEqual([0, 2, 4, 6, 8, 10, 12, 14, 16, 18]);
   });
 });
 
 test('Series.value_counts', () => {
   const s      = Series.new({type: new Int32, data: [110, 120, 100, 110, 120, 120]});
   const result = s.value_counts();
-  const count  = [...result.count.toArrow()];
-  const value  = [...result.value.toArrow()];
+  const count  = [...result.count];
+  const value  = [...result.value];
 
   const countMap: Record<number, number> = {100: 1, 110: 2, 120: 3};
 
@@ -392,5 +392,5 @@ ${false}       | ${[null, null, 1, 2, 3, 4, 4]} | ${[null, null, 1, 2, 3, 4]}
 `('Series.unique($nulls_equal)', ({nulls_equal, data, expected}) => {
   const s      = Series.new({type: new Int32, data});
   const result = s.unique(nulls_equal);
-  expect([...result.toArrow()]).toEqual(expected);
+  expect([...result]).toEqual(expected);
 });

--- a/modules/cudf/test/dataframe/read-csv-tests.ts
+++ b/modules/cudf/test/dataframe/read-csv-tests.ts
@@ -36,9 +36,9 @@ describe('DataFrame.readCSV', () => {
       sources: [Buffer.from(makeCSVString({rows}))],
       dataTypes: {a: 'int32', b: 'float64', c: 'str'},
     });
-    expect(df.get('a').toArrow().values).toEqual(new Int32Array([0, 1, 2]));
-    expect(df.get('b').toArrow().toArray()).toEqual(new Float64Array([1.0, 2.0, 3.0]));
-    expect([...df.get('c').toArrow()]).toEqual(['2', '3', '4']);
+    expect(df.get('a').data.toArray()).toEqual(new Int32Array([0, 1, 2]));
+    expect(df.get('b').data.toArray()).toEqual(new Float64Array([1.0, 2.0, 3.0]));
+    expect([...df.get('c')]).toEqual(['2', '3', '4']);
   });
 
   test('can read a CSV file', async () => {
@@ -55,9 +55,9 @@ describe('DataFrame.readCSV', () => {
       sources: [path],
       dataTypes: {a: 'int32', b: 'float64', c: 'str'},
     });
-    expect(df.get('a').toArrow().values).toEqual(new Int32Array([0, 1, 2]));
-    expect(df.get('b').toArrow().toArray()).toEqual(new Float64Array([1.0, 2.0, 3.0]));
-    expect([...df.get('c').toArrow()]).toEqual(['2', '3', '4']);
+    expect(df.get('a').data.toArray()).toEqual(new Int32Array([0, 1, 2]));
+    expect(df.get('b').data.toArray()).toEqual(new Float64Array([1.0, 2.0, 3.0]));
+    expect([...df.get('c')]).toEqual(['2', '3', '4']);
     await new Promise<void>((resolve, reject) =>
                               rimraf(path, (err?: Error|null) => err ? reject(err) : resolve()));
   });

--- a/modules/cudf/test/dataframe/write-csv-tests.ts
+++ b/modules/cudf/test/dataframe/write-csv-tests.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Float64Buffer, Int32Buffer, setDefaultAllocator, Uint8Buffer} from '@nvidia/cuda';
-import {DataFrame, Float64, Int32, Series, Uint8, Utf8String} from '@rapidsai/cudf';
+import {Float64Buffer, Int32Buffer, setDefaultAllocator} from '@nvidia/cuda';
+import {DataFrame, Float64, Int32, Series} from '@rapidsai/cudf';
 import {DeviceBuffer} from '@rapidsai/rmm';
 
 import {makeCSVString, toStringAsync} from './utils';
@@ -30,14 +30,7 @@ describe('DataFrame.writeCSV', () => {
     const df = new DataFrame({
       a: Series.new({length: 3, type: new Int32, data: new Int32Buffer([0, 1, 2])}),
       b: Series.new({length: 3, type: new Float64, data: new Float64Buffer([1.0, 2.0, 3.0])}),
-      c: Series.new({
-        type: new Utf8String(),
-        length: 3,
-        children: [
-          Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3])}),
-          Series.new({type: new Uint8, data: new Uint8Buffer(Buffer.from('234'))})
-        ]
-      }),
+      c: Series.new(['2', '3', '4']),
     });
     expect((await toStringAsync(df.toCSV()))).toEqual(makeCSVString({rows}));
   });


### PR DESCRIPTION
PR with a bit of cleanup in the tests. `[...ser.toArrow()]` is redundant now that we have the `Series[Symbol.iterator]()` method, because it internally calls `this.toArrow()`.