### PR TITLE
[FEA] Add `Series.getJSONObject`

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -224,6 +224,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `value_counts`       |                     |                     |                     |
 | `values_to_string`   |                     |                     |                     |
 | `where`              |                     |                     |                     |
+| `get_json_object`    |                     | ✅ (`getJSONObject`)|                     |
 
 ### DataFrame
 

--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -201,6 +201,8 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Column::variance>("var"),
                        InstanceMethod<&Column::std>("std"),
                        InstanceMethod<&Column::quantile>("quantile"),
+                       // column/strings/json.cpp
+                       InstanceMethod<&Column::get_json_object>("getJSONObject"),
                        // column/replacement.cpp
                        InstanceMethod<&Column::replace_nulls>("replaceNulls"),
                        InstanceMethod<&Column::replace_nans>("replaceNaNs"),

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -1060,6 +1060,8 @@ export interface Column<T extends DataType = any> {
    * @returns column without duplicate values
    */
   drop_duplicates(nullsEqual?: boolean, memoryResource?: MemoryResource): Column<T>;
+
+  getJSONObject(jsonPath?: string, memoryResource?: MemoryResource): Column<T>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/cudf/src/column/json.cpp
+++ b/modules/cudf/src/column/json.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <node_cudf/column.hpp>
+#include <node_cudf/scalar.hpp>
+
+#include <cudf/strings/json.hpp>
+
+namespace nv {
+
+Column::wrapper_t Column::get_json_object(std::string const& json_path,
+                                          rmm::mr::device_memory_resource* mr) {
+  try {
+    return Column::New(Env(), cudf::strings::get_json_object(this->view(), json_path, mr));
+  } catch (std::exception const& e) { NAPI_THROW(Napi::Error::New(Env(), e.what())); }
+}
+
+Napi::Value Column::get_json_object(Napi::CallbackInfo const& info) {
+  try {
+    if (info.Length() < 1) {
+      NODE_CUDF_THROW("Column get_json_object expects a jsonPath and optional MemoryResource",
+                      info.Env());
+    }
+    CallbackArgs args{info};
+    return get_json_object(args[0], args[1]);
+  } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(info.Env(), e.what())); }
+  throw Napi::Error::New(info.Env(), "get_json_object requires a string value as json_path");
+}
+
+}  // namespace nv

--- a/modules/cudf/src/column/json.cpp
+++ b/modules/cudf/src/column/json.cpp
@@ -31,7 +31,6 @@ Napi::Value Column::get_json_object(Napi::CallbackInfo const& info) {
   try {
     return get_json_object(args[0], args[1]);
   } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(info.Env(), e.what())); }
-  throw Napi::Error::New(info.Env(), "get_json_object requires a string value as json_path");
 }
 
 }  // namespace nv

--- a/modules/cudf/src/column/json.cpp
+++ b/modules/cudf/src/column/json.cpp
@@ -27,12 +27,8 @@ Column::wrapper_t Column::get_json_object(std::string const& json_path,
 }
 
 Napi::Value Column::get_json_object(Napi::CallbackInfo const& info) {
+  CallbackArgs args{info};
   try {
-    if (info.Length() < 1) {
-      NODE_CUDF_THROW("Column get_json_object expects a jsonPath and optional MemoryResource",
-                      info.Env());
-    }
-    CallbackArgs args{info};
     return get_json_object(args[0], args[1]);
   } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(info.Env(), e.what())); }
   throw Napi::Error::New(info.Env(), "get_json_object requires a string value as json_path");

--- a/modules/cudf/src/column/json.cpp
+++ b/modules/cudf/src/column/json.cpp
@@ -28,9 +28,7 @@ Column::wrapper_t Column::get_json_object(std::string const& json_path,
 
 Napi::Value Column::get_json_object(Napi::CallbackInfo const& info) {
   CallbackArgs args{info};
-  try {
-    return get_json_object(args[0], args[1]);
-  } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(info.Env(), e.what())); }
+  return get_json_object(args[0], args[1]);
 }
 
 }  // namespace nv

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -613,6 +613,11 @@ struct Column : public EnvLocalObjectWrap<Column> {
     cudf::scalar const& value,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+  // column/strings/json.cpp
+  Column::wrapper_t get_json_object(
+    std::string const& json_path,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
   // column/replace.cpp
   Column::wrapper_t replace_nulls(
     cudf::column_view const& replacement,
@@ -765,6 +770,9 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Napi::Value variance(Napi::CallbackInfo const& info);
   Napi::Value std(Napi::CallbackInfo const& info);
   Napi::Value quantile(Napi::CallbackInfo const& info);
+
+  // column/strings/json.cpp
+  Napi::Value get_json_object(Napi::CallbackInfo const& info);
 
   // column/replace.cpp
   Napi::Value replace_nulls(Napi::CallbackInfo const& info);

--- a/modules/cudf/src/series/string.ts
+++ b/modules/cudf/src/series/string.ts
@@ -155,4 +155,31 @@ export class StringSeries extends Series<Utf8String> {
     const pat_string = pattern instanceof RegExp ? pattern.source : pattern;
     return Series.new(this._col.matchesRe(pat_string, memoryResource));
   }
+
+  /**
+   * Applies a JSONPath(string) where each row in the series is a valid json string. Returns New
+   * StringSeries containing the retrieved json object strings
+   *
+   * @param jsonPath The JSONPath string to be applied to each row of the input column
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = const lines = Series.new([
+   *  {foo: {bar: "baz"}},
+   *  {foo: {baz: "bar"}},
+   * ].map(JSON.stringify)); // StringSeries ['{"foo":{"bar":"baz"}}', '{"foo":{"baz":"bar"}}']
+   *
+   * a.getJSONObject("$.foo") // StringSeries ['{"bar":"baz"}', '{"baz":"bar"}']
+   * a.getJSONObject("$.foo.bar") // StringSeries ["baz", null]
+   *
+   * // parse the resulting strings using JSON.parse
+   * [...a.getJSONObject("$.foo").map(JSON.parse)] // object [{ bar: 'baz' }, { baz: 'bar' }]
+   * ```
+   */
+  getJSONObject(jsonPath: string, memoryResource?: MemoryResource): StringSeries {
+    return Series.new(this._col.getJSONObject(jsonPath, memoryResource));
+  }
 }

--- a/modules/cudf/test/series/string-tests.ts
+++ b/modules/cudf/test/series/string-tests.ts
@@ -56,10 +56,12 @@ describe.each([['foo'], [/foo/], [/foo/ig]])('Series regex search (pattern=%p)',
 test('getJSONObject', () => {
   const object_data =
     [{goat: {id: 0, species: 'Capra Hircus'}}, {leopard: {id: 1, species: 'Panthera pardus'}}];
-  const a = Series.new((object_data as any).map(JSON.stringify));
+  const a = Series.new(object_data.map((x) => JSON.stringify(x)));
 
-  expect(JSON.parse(a.getJSONObject('$.goat').getValue(0))).toEqual(object_data[0].goat);
-  expect(JSON.parse(a.getJSONObject('$.leopard').getValue(1))).toEqual(object_data[1].leopard);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  expect(JSON.parse(a.getJSONObject('$.goat').getValue(0)!)).toEqual(object_data[0].goat);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  expect(JSON.parse(a.getJSONObject('$.leopard').getValue(1)!)).toEqual(object_data[1].leopard);
 
   const b = Series.new(['']);
   expect([...b.getJSONObject('$')]).toStrictEqual([null]);

--- a/modules/cudf/test/series/string-tests.ts
+++ b/modules/cudf/test/series/string-tests.ts
@@ -51,3 +51,18 @@ describe.each([['foo'], [/foo/], [/foo/ig]])('Series regex search (pattern=%p)',
     expect([...s.matchesRe(pattern)]).toEqual(expected);
   });
 });
+
+// getJSONObject tests
+test('getJSONObject', () => {
+  const object_data =
+    [{goat: {id: 0, species: 'Capra Hircus'}}, {leapord: {id: 1, species: 'Panthera pardus'}}];
+  const a = Series.new((object_data as any).map(JSON.stringify));
+
+  expect(([...a.getJSONObject('$.goat')] as any).map(JSON.parse)[0]).toEqual(object_data[0].goat);
+  expect(([...a.getJSONObject('$.leapord')] as any).map(JSON.parse)[1])
+    .toEqual(object_data[1].leapord);
+
+  const b = Series.new(['']);
+  expect([...b.getJSONObject('$')]).toStrictEqual([null]);
+  expect([...b.getJSONObject('')]).toStrictEqual([]);
+});

--- a/modules/cudf/test/series/string-tests.ts
+++ b/modules/cudf/test/series/string-tests.ts
@@ -55,12 +55,12 @@ describe.each([['foo'], [/foo/], [/foo/ig]])('Series regex search (pattern=%p)',
 // getJSONObject tests
 test('getJSONObject', () => {
   const object_data =
-    [{goat: {id: 0, species: 'Capra Hircus'}}, {leapord: {id: 1, species: 'Panthera pardus'}}];
+    [{goat: {id: 0, species: 'Capra Hircus'}}, {leopard: {id: 1, species: 'Panthera pardus'}}];
   const a = Series.new((object_data as any).map(JSON.stringify));
 
   expect(([...a.getJSONObject('$.goat')] as any).map(JSON.parse)[0]).toEqual(object_data[0].goat);
-  expect(([...a.getJSONObject('$.leapord')] as any).map(JSON.parse)[1])
-    .toEqual(object_data[1].leapord);
+  expect(([...a.getJSONObject('$.leopard')] as any).map(JSON.parse)[1])
+    .toEqual(object_data[1].leopard);
 
   const b = Series.new(['']);
   expect([...b.getJSONObject('$')]).toStrictEqual([null]);

--- a/modules/cudf/test/series/string-tests.ts
+++ b/modules/cudf/test/series/string-tests.ts
@@ -58,9 +58,8 @@ test('getJSONObject', () => {
     [{goat: {id: 0, species: 'Capra Hircus'}}, {leopard: {id: 1, species: 'Panthera pardus'}}];
   const a = Series.new((object_data as any).map(JSON.stringify));
 
-  expect(([...a.getJSONObject('$.goat')] as any).map(JSON.parse)[0]).toEqual(object_data[0].goat);
-  expect(([...a.getJSONObject('$.leopard')] as any).map(JSON.parse)[1])
-    .toEqual(object_data[1].leopard);
+  expect(JSON.parse(a.getJSONObject('$.goat').getValue(0))).toEqual(object_data[0].goat);
+  expect(JSON.parse(a.getJSONObject('$.leopard').getValue(1))).toEqual(object_data[1].leopard);
 
   const b = Series.new(['']);
   expect([...b.getJSONObject('$')]).toStrictEqual([null]);


### PR DESCRIPTION
implements #179 

Example usage:
```javascript
const { Series } = require('@rapidsai/cudf');
const object_data = [{ goat: { id: 0, species: "Capra Hircus" } }, { leapord: { id: 1, species: "Panthera pardus" } }];
const a = Series.new(object_data.map(JSON.stringify));

console.log([...a.getJSONObject(`$.goat`)].map(JSON.parse)[0]); //{ id: 0, species: 'Capra Hircus' }
```