### PR TITLE
Remove libboost-filesystem-dev from C++ dependencies

### DIFF
--- a/dockerfiles/devel.Dockerfile
+++ b/dockerfiles/devel.Dockerfile
@@ -34,8 +34,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
     # GLEW dependencies
     build-essential libxmu-dev libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev \
-    # cuDF dependencies
-    libboost-filesystem-dev \
     # cuSpatial dependencies
     libgdal-dev \
  && apt autoremove -y \

--- a/dockerfiles/runtime.Dockerfile
+++ b/dockerfiles/runtime.Dockerfile
@@ -10,8 +10,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install dependencies
 RUN apt update -y \
  && apt install --no-install-recommends -y \
-    # cuDF dependencies
-    libboost-filesystem-dev \
     # cuSpatial dependencies
     libgdal-dev \
  && apt autoremove -y \

--- a/modules/core/bin/install-deps/debian.sh
+++ b/modules/core/bin/install-deps/debian.sh
@@ -77,8 +77,6 @@ install_vscode_extensions() {
 install_apt_deps jq software-properties-common \
     # cuSpatial dependencies
     libgdal-dev \
-    # cuDF dependencies
-    libboost-filesystem-dev \
     # X11 dependencies
     libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev \
     # node-canvas dependencies


### PR DESCRIPTION
Now that cuDF [has removed the boost dependency](https://github.com/rapidsai/cudf/pull/7932), we can stop installing it too.

This PR will require rebuilding the containers + building the newest version of libcudf branch-0.20:

```
$ yarn docker:build:devel
$ yarn docker:run:devel bash -c 'yarn nuke:from:orbit'
```