### PR TITLE
[FEA] Create `ListSeries` from JS Arrays, add `ListSeries.getValue()`

### DIFF
--- a/modules/cudf/src/node_cudf/utilities/cpp_to_napi.hpp
+++ b/modules/cudf/src/node_cudf/utilities/cpp_to_napi.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include "scalar_to_value.hpp"
+
 #include <nv_node/utilities/cpp_to_napi.hpp>
 
 #include <cudf/scalar/scalar.hpp>
@@ -82,87 +84,6 @@ inline Napi::Value CPPToNapi::operator()(cudf::timestamp_ns const& val) const {
   return (*this)(val.time_since_epoch());
 }
 
-namespace detail {
-
-struct get_scalar_value {
-  Napi::Env env;
-  template <typename T>
-  inline std::enable_if_t<cudf::is_index_type<T>(), Napi::Value> operator()(
-    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
-    if (!scalar->is_valid(stream)) { return env.Null(); }
-    switch (scalar->type().id()) {
-      case cudf::type_id::INT64:
-        return Napi::BigInt::New(
-          env, static_cast<cudf::numeric_scalar<int64_t>*>(scalar.get())->value(stream));
-      case cudf::type_id::UINT64:
-        return Napi::BigInt::New(
-          env, static_cast<cudf::numeric_scalar<uint64_t>*>(scalar.get())->value(stream));
-      default:
-        return Napi::Number::New(
-          env, static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream));
-    }
-  }
-  template <typename T>
-  inline std::enable_if_t<cudf::is_floating_point<T>(), Napi::Value> operator()(
-    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
-    return scalar->is_valid(stream)
-             ? Napi::Number::New(env,
-                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
-             : env.Null();
-  }
-  template <typename T>
-  inline std::enable_if_t<std::is_same<T, bool>::value, Napi::Value> operator()(
-    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
-    return scalar->is_valid(stream)
-             ? Napi::Boolean::New(
-                 env, static_cast<cudf::numeric_scalar<bool>*>(scalar.get())->value(stream))
-             : env.Null();
-  }
-  template <typename T>
-  inline std::enable_if_t<std::is_same<T, cudf::string_view>::value, Napi::Value> operator()(
-    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
-    return scalar->is_valid(stream)
-             ? CPPToNapi(env)(static_cast<cudf::string_scalar*>(scalar.get())->to_string(stream))
-             : env.Null();
-  }
-  template <typename T>
-  inline std::enable_if_t<cudf::is_duration<T>(), Napi::Value> operator()(
-    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
-    return scalar->is_valid(stream)
-             ? CPPToNapi(env)(static_cast<cudf::duration_scalar<T>*>(scalar.get())->value(stream))
-             : env.Null();
-  }
-  template <typename T>
-  inline std::enable_if_t<cudf::is_timestamp<T>(), Napi::Value> operator()(
-    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
-    return scalar->is_valid(stream)
-             ? CPPToNapi(env)(static_cast<cudf::timestamp_scalar<T>*>(scalar.get())->value(stream))
-             : env.Null();
-  }
-  template <typename T>
-  inline std::enable_if_t<cudf::is_fixed_point<T>(), Napi::Value> operator()(
-    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
-    return scalar->is_valid(stream)
-             ? CPPToNapi(env)(
-                 static_cast<cudf::fixed_point_scalar<T>*>(scalar.get())->value(stream))
-             : env.Null();
-  }
-  template <typename T>
-  inline std::enable_if_t<!(cudf::is_index_type<T>() ||                   //
-                            cudf::is_floating_point<T>() ||               //
-                            std::is_same<T, bool>::value ||               //
-                            std::is_same<T, cudf::string_view>::value ||  //
-                            cudf::is_duration<T>() ||                     //
-                            cudf::is_timestamp<T>() ||                    //
-                            cudf::is_fixed_point<T>()),
-                          Napi::Value>
-  operator()(std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
-    NAPI_THROW(Napi::Error::New(env, "Unsupported dtype"));
-  }
-};
-
-}  // namespace detail
-
 template <>
 inline Napi::Value CPPToNapi::operator()(std::unique_ptr<cudf::scalar> const& scalar) const {
   return cudf::type_dispatcher(scalar->type(), detail::get_scalar_value{Env()}, scalar);
@@ -225,11 +146,6 @@ inline Value Value::From(napi_env env, cudf::timestamp_us const& val) {
 template <>
 inline Value Value::From(napi_env env, cudf::timestamp_ns const& val) {
   return Value::From(env, val.time_since_epoch());
-}
-
-template <>
-inline Value Value::From(napi_env env, std::unique_ptr<cudf::scalar> const& scalar) {
-  return cudf::type_dispatcher(scalar->type(), nv::detail::get_scalar_value{env}, scalar);
 }
 
 }  // namespace Napi

--- a/modules/cudf/src/node_cudf/utilities/scalar_to_value.hpp
+++ b/modules/cudf/src/node_cudf/utilities/scalar_to_value.hpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <node_cudf/column.hpp>
+
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/traits.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+#include <cudf/wrappers/durations.hpp>
+#include <cudf/wrappers/timestamps.hpp>
+
+#include <napi.h>
+
+namespace nv {
+namespace detail {
+
+struct get_scalar_value {
+  Napi::Env env;
+  template <typename T>
+  inline std::enable_if_t<cudf::is_index_type<T>(), Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    if (!scalar->is_valid(stream)) { return env.Null(); }
+    switch (scalar->type().id()) {
+      case cudf::type_id::INT64:
+        return Napi::BigInt::New(
+          env, static_cast<cudf::numeric_scalar<int64_t>*>(scalar.get())->value(stream));
+      case cudf::type_id::UINT64:
+        return Napi::BigInt::New(
+          env, static_cast<cudf::numeric_scalar<uint64_t>*>(scalar.get())->value(stream));
+      default:
+        return Napi::Number::New(
+          env, static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream));
+    }
+  }
+  template <typename T>
+  inline std::enable_if_t<cudf::is_floating_point<T>(), Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::Number::New(env,
+                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same<T, bool>::value, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::Boolean::New(
+                 env, static_cast<cudf::numeric_scalar<bool>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same<T, cudf::string_view>::value, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? CPPToNapi(env)(static_cast<cudf::string_scalar*>(scalar.get())->to_string(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<cudf::is_duration<T>(), Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? CPPToNapi(env)(static_cast<cudf::duration_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<cudf::is_timestamp<T>(), Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? CPPToNapi(env)(static_cast<cudf::timestamp_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<cudf::is_fixed_point<T>(), Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? CPPToNapi(env)(
+                 static_cast<cudf::fixed_point_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same<T, cudf::list_view>::value, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Column::New(env,
+                           std::make_unique<cudf::column>(
+                             // The list_scalar's view is copied here because its underlying column
+                             // cannot be moved.
+                             static_cast<cudf::list_scalar*>(scalar.get())->view(),
+                             stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<!(cudf::is_index_type<T>() ||                   //
+                            cudf::is_floating_point<T>() ||               //
+                            std::is_same<T, bool>::value ||               //
+                            std::is_same<T, cudf::string_view>::value ||  //
+                            cudf::is_duration<T>() ||                     //
+                            cudf::is_timestamp<T>() ||                    //
+                            cudf::is_fixed_point<T>() ||                  //
+                            std::is_same<T, cudf::list_view>::value),
+                          Napi::Value>
+  operator()(std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    NAPI_THROW(Napi::Error::New(env, "Unsupported dtype"));
+  }
+};
+
+}  // namespace detail
+
+}  // namespace nv
+
+namespace Napi {
+
+template <>
+inline Value Value::From(napi_env env, std::unique_ptr<cudf::scalar> const& scalar) {
+  return cudf::type_dispatcher(scalar->type(), nv::detail::get_scalar_value{env}, scalar);
+}
+
+}  // namespace Napi

--- a/modules/cudf/src/node_cudf/utilities/value_to_scalar.hpp
+++ b/modules/cudf/src/node_cudf/utilities/value_to_scalar.hpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <node_cudf/column.hpp>
+
+#include <cudf/types.hpp>
+#include <cudf/utilities/traits.hpp>
+
+#include <napi.h>
+
+namespace nv {
+namespace detail {
+
+struct set_scalar_value {
+  Napi::Value val;
+
+  template <typename T>
+  inline std::enable_if_t<cudf::is_numeric<T>(), void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())->set_value(NapiToCPP(val), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same<T, cudf::string_view>::value, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    scalar.reset(new cudf::string_scalar(val.ToString(), true, stream));
+  }
+  template <typename T>
+  inline std::enable_if_t<cudf::is_duration<T>(), void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::duration_scalar<T>*>(scalar.get())->set_value(NapiToCPP(val), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<cudf::is_timestamp<T>(), void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::timestamp_scalar<T>*>(scalar.get())->set_value(NapiToCPP(val), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<cudf::is_fixed_point<T>(), void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    scalar.reset(new cudf::fixed_point_scalar<T>(val.ToNumber(), true, stream));
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same<T, cudf::list_view>::value, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    scalar.reset(new cudf::list_scalar(*Column::Unwrap(val.ToObject()), true, stream));
+  }
+  template <typename T>
+  inline std::enable_if_t<!(cudf::is_numeric<T>() ||                      //
+                            std::is_same<T, cudf::string_view>::value ||  //
+                            cudf::is_duration<T>() ||                     //
+                            cudf::is_timestamp<T>() ||                    //
+                            cudf::is_fixed_point<T>() ||                  //
+                            std::is_same<T, cudf::list_view>::value),
+                          void>
+  operator()(std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    NAPI_THROW(Napi::Error::New(val.Env(), "Unsupported dtype"));
+  }
+};
+
+}  // namespace detail
+}  // namespace nv

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -534,51 +534,6 @@ export class AbstractSeries<T extends DataType = any> {
   filter(mask: Series<Bool8>): Series<T> { return this.__construct(this._col.gather(mask._col)); }
 
   /**
-   * Return a value at the specified index to host memory
-   *
-   * @param index the index in this Series to return a value for
-   *
-   * @example
-   * ```typescript
-   * import {Series} from "@rapidsai/cudf";
-   *
-   * // Float64Series
-   * Series.new([1, 2, 3]).getValue(0) // 1
-   * // StringSeries
-   * Series.new(["foo", "bar", "test"]).getValue(2) // "test"
-   * // Bool8Series
-   * Series.new([false, true, true]).getValue(3) // throws index out of bounds error
-   * ```
-   */
-  getValue(index: number) { return this._col.getValue(index); }
-
-  /**
-   * set value at the specified index
-   *
-   * @param index the index in this Series to set a value for
-   * @param value the value to set at `index`
-   *
-   * @example
-   * ```typescript
-   * import {Series} from "@rapidsai/cudf";
-   *
-   * // Float64Series
-   * const a = Series.new([1, 2, 3]);
-   * a.setValue(0, -1) // inplace update [-1, 2, 3]
-   *
-   * // StringSeries
-   * const b = Series.new(["foo", "bar", "test"])
-   * b.setValue(1,"test1") // inplace update ["foo", "test1", "test"]
-   * // Bool8Series
-   * const c = Series.new([false, true, true])
-   * c.cetValue(2, false) // inplace update [false, true, false]
-   * ```
-   */
-  setValue(index: number, value: T['scalarType']): void {
-    this._col = this.scatter(value, [index])._col as Column<T>;
-  }
-
-  /**
    * set values at the specified indices
    *
    * @param indices the indices in this Series to set values for

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -192,7 +192,7 @@ export class AbstractSeries<T extends DataType = any> {
    * const b = Series.new(a._col); // Int32Series [1, 2, 3, 4]
    * ```
    */
-  static new<T extends DataType>(input: Column<T>|SeriesProps<T>): Series<T>;
+  static new<T extends DataType>(input: AbstractSeries<T>|Column<T>|SeriesProps<T>): Series<T>;
   /**
    * Create a new cudf.StringSeries
    *
@@ -200,7 +200,8 @@ export class AbstractSeries<T extends DataType = any> {
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
    *
-   * const a = Series.new(["foo", "bar", "test",null]); // StringSeries ["foo", "bar", "test", null]
+   * // StringSeries ["foo", "bar", "test", null]
+   * const a = Series.new(["foo", "bar", "test", null]);
    * ```
    */
   static new(input: (string|null|undefined)[]): Series<Utf8String>;
@@ -211,7 +212,8 @@ export class AbstractSeries<T extends DataType = any> {
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
    *
-   * const a = Series.new([1, 2, 3,, 4]); // Float64Series [1, 2, 3, null, 4]
+   * // Float64Series [1, 2, 3, null, 4]
+   * const a = Series.new([1, 2, 3, undefined, 4]);
    * ```
    */
   static new(input: (number|null|undefined)[]): Series<Float64>;
@@ -222,7 +224,8 @@ export class AbstractSeries<T extends DataType = any> {
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
    *
-   * const a = Series.new([1n, 2n, 3n,undefined, 4n]); // Int64Series [1n, 2n, 3n, null, 4n]
+   * // Int64Series [1n, 2n, 3n, null, 4n]
+   * const a = Series.new([1n, 2n, 3n, undefined, 4n]);
    * ```
    */
   static new(input: (bigint|null|undefined)[]): Series<Int64>;
@@ -233,20 +236,80 @@ export class AbstractSeries<T extends DataType = any> {
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
    *
-   * const a = Series.new([true, false, true, false]); // Bool8Series [true, false, true, false]
+   * // Bool8Series [true, false, null, false]
+   * const a = Series.new([true, false, undefined, false]);
    * ```
    */
   static new(input: (boolean|null|undefined)[]): Series<Bool8>;
-  static new<T extends DataType>(input: Column<T>|SeriesProps<T>|arrow.Vector<T>|
+  /**
+   * Create a new cudf.ListSeries that contain cudf.StringSeries elements.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // ListSeries [["foo", "bar"], ["test", null]]
+   * const a = Series.new([["foo", "bar"], ["test",null]]);
+   * a.getValue(0) // StringSeries ["foo", "bar"]
+   * a.getValue(1) // StringSeries ["test", null]
+   * ```
+   */
+  static new(input: (string|null|undefined)[][]): Series<List<Utf8String>>;
+  /**
+   * Create a new cudf.ListSeries that contain cudf.Float64Series elements.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // ListSeries [[1, 2], [3, null, 4]]
+   * const a = Series.new([[1, 2], [3, undefined, 4]]);
+   * a.getValue(0) // Float64Series [1, 2]
+   * a.getValue(1) // Float64Series [3, null, 4]
+   * ```
+   */
+  static new(input: (number|null|undefined)[][]): Series<List<Float64>>;
+  /**
+   * Create a new cudf.ListSeries that contain cudf.Int64Series elements.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // ListSeries [[1n, 2n], [3n, null, 4n]]
+   * const a = Series.new([[1n, 2n], [3n, undefined, 4n]]);
+   * a.getValue(0) // Int64Series [1n, 2n]
+   * a.getValue(1) // Int64Series [3n, null, 4n]
+   * ```
+   */
+  static new(input: (bigint|null|undefined)[][]): Series<List<Int64>>;
+  /**
+   * Create a new cudf.ListSeries that contain cudf.Bool8Series elements.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // ListSeries [[true, false], [null, false]]
+   * const a = Series.new([[true, false], [undefined, false]]);
+   * a.getValue(0) // Bool8Series [true, false]
+   * a.getValue(1) // Bool8Series [null, false]
+   * ```
+   */
+  static new(input: (boolean|null|undefined)[][]): Series<List<Bool8>>;
+
+  static new<T extends DataType>(input: AbstractSeries<T>|Column<T>|SeriesProps<T>|arrow.Vector<T>|
                                  (string|null|undefined)[]|(number|null|undefined)[]|
-                                 (bigint|null|undefined)[]|(boolean|null|undefined)[]) {
+                                 (bigint|null|undefined)[]|(boolean|null|undefined)[]|
+                                 (string|null|undefined)[][]|(number|null|undefined)[][]|
+                                 (bigint|null|undefined)[][]|(boolean|null|undefined)[][]) {
     return columnToSeries(asColumn<T>(input)) as any as Series<T>;
   }
 
   /** @ignore */
   public _col: Column<T>;
 
-  protected constructor(input: SeriesProps<T>|Column<T>|arrow.Vector<T>) {
+  protected constructor(input: AbstractSeries<T>|SeriesProps<T>|Column<T>|arrow.Vector<T>) {
     this._col = asColumn<T>(input);
   }
 
@@ -557,8 +620,8 @@ export class AbstractSeries<T extends DataType = any> {
   /**
    * Copy the underlying device memory to host, and return an Iterator of the values.
    */
-  [Symbol.iterator](): IterableIterator<T['scalarType']|null> {
-    return this.toArrow()[Symbol.iterator]();
+  [Symbol.iterator](): IterableIterator<T['TValue']|null> {
+    return this.toArrow()[Symbol.iterator]() as IterableIterator<T['TValue']|null>;
   }
 
   /**
@@ -830,21 +893,72 @@ export {
 };
 
 function inferType(value: any[]): DataType {
-  if (value.length == 0 || (value.every((val) => typeof val === 'number' || val == null)))
-    return new Float64;
-  if (value.every((val) => typeof val === 'string' || val == null)) return new Utf8String;
-  if (value.every((val) => typeof val === 'bigint' || val == null)) return new Int64;
-  if (value.every((val) => typeof val === 'boolean' || val == null)) return new Bool8;
-  throw new TypeError('Unable to infer type series type, explicit type declaration expected');
+  if (value.length === 0) { return new Float64; }
+  let nullsCount    = 0;
+  let arraysCount   = 0;
+  let objectsCount  = 0;
+  let numbersCount  = 0;
+  let stringsCount  = 0;
+  let bigintsCount  = 0;
+  let booleansCount = 0;
+  let unknownCount  = 0;
+  value.forEach((val) => {
+    if (val == null) { return ++nullsCount; }
+    switch (typeof val) {
+      case 'bigint': return ++bigintsCount;
+      case 'boolean': return ++booleansCount;
+      case 'number': return ++numbersCount;
+      case 'string': return ++stringsCount;
+      case 'object': return Array.isArray(val) ? ++arraysCount : ++objectsCount;
+    }
+    return ++unknownCount;
+  });
+  if (unknownCount === 0) {
+    if (numbersCount + nullsCount === value.length) {
+      return new Float64;
+    } else if (stringsCount + nullsCount === value.length) {
+      return new Utf8String;
+    } else if (bigintsCount + nullsCount === value.length) {
+      return new Int64;
+    } else if (booleansCount + nullsCount === value.length) {
+      return new Bool8;
+    } else if (arraysCount + nullsCount === value.length) {
+      const childType = inferType(value[value.findIndex((ary) => ary != null)]);
+      if (value.every((ary) => ary == null || childType.compareTo(inferType(ary)))) {
+        return new List(new arrow.Field('', childType));
+      }
+    } else if (objectsCount + nullsCount === value.length) {
+      const fields = new Map<string, arrow.Field>();
+      value.forEach((val) => {
+        Object.keys(val).forEach((key) => {
+          if (!fields.has(key)) {
+            // use the type inferred for the first instance of a found key
+            fields.set(key, new arrow.Field(key, inferType(val[key])));
+          }
+        });
+      }, {});
+      return new Struct<any>([...fields.values()]);
+    }
+  }
+  throw new TypeError(
+    'Unable to infer Series type from input values, explicit type declaration expected');
 }
 
-function asColumn<T extends DataType>(value: SeriesProps<T>|Column<T>|arrow.Vector<T>|
-                                      (string | null | undefined)[]|(number | null | undefined)[]|
-                                      (bigint | null | undefined)[]|
-                                      (boolean | null | undefined)[]): Column<T> {
+function asColumn<T extends DataType>(
+  value: AbstractSeries<T>|SeriesProps<T>|Column<T>|arrow.Vector<T>  //
+  |(string | null | undefined)[]                                     //
+  |(number | null | undefined)[]                                     //
+  |(bigint | null | undefined)[]                                     //
+  |(boolean | null | undefined)[]                                    //
+  |(string | null | undefined)[][]                                   //
+  |(number | null | undefined)[][]                                   //
+  |(bigint | null | undefined)[][]                                   //
+  |(boolean | null | undefined)[][]                                  //
+  ): Column<T> {
+  if (value instanceof AbstractSeries) { return value._col; }
   if (Array.isArray(value)) {
     return fromArrow(arrow.Vector.from(
-             {type: inferType(value), values: value, highWaterMark: Infinity})) as any;
+             {type: inferType(value), values: value as any, highWaterMark: Infinity})) as any;
   }
   if (value instanceof arrow.Vector) { return fromArrow(value) as any; }
   if (!value.type && Array.isArray(value.data)) {

--- a/modules/cudf/src/series/list.ts
+++ b/modules/cudf/src/series/list.ts
@@ -74,6 +74,11 @@ export class ListSeries<T extends DataType> extends Series<List<T>> {
   // TODO: account for this.offset
   get elements(): Series<T> { return Series.new(this._col.getChild<T>(1)); }
 
+  getValue(index: number): Series<T>|null {
+    const value = this._col.getValue(index);
+    return value === null ? null : Series.new(value);
+  }
+
   /** @ignore */
   protected __construct(col: Column<List<T>>) {
     return new ListSeries(Object.assign(col, {type: fixNames(this.type, col.type)}));

--- a/modules/cudf/src/series/list.ts
+++ b/modules/cudf/src/series/list.ts
@@ -99,33 +99,6 @@ export class ListSeries<T extends DataType> extends Series<List<T>> {
     return value === null ? null : Series.new(value);
   }
 
-  /**
-   * set value at the specified index
-   *
-   * @param index the index in this Series to set a value for
-   * @param value the value to set at `index`
-   *
-   * @example
-   * ```typescript
-   * import {Series} from "@rapidsai/cudf";
-   *
-   * // Series<List<Float64>>
-   * const a = Series.new([[1, 2], [3]])
-   * a.setValue(0, [-1]) // inplace update -> Series([[-1], [3]])
-   *
-   * // Series<List<Utf8String>>
-   * const b = Series.new([["foo", "bar"], ["test"]])
-   * b.setValue(0, ["test1"]) // inplace update -> Series([["test1"] ["test"]])
-   *
-   * // Series<List<Bool8>>
-   * const c = Series.new([[false, true], [true]])
-   * c.setValue(0, [false]) // inplace update -> Series([[false], [true]])
-   * ```
-   */
-  setValue(index: number, value: T['scalarType'][]|Series<T>): void {
-    this._col = this.scatter(Series.new<T>(<any>value)._col as Column<T>, [index])._col;
-  }
-
   /** @ignore */
   protected __construct(col: Column<List<T>>) {
     return new ListSeries(Object.assign(col, {type: fixNames(this.type, col.type)}));

--- a/modules/cudf/src/series/list.ts
+++ b/modules/cudf/src/series/list.ts
@@ -84,12 +84,14 @@ export class ListSeries<T extends DataType> extends Series<List<T>> {
    * ```typescript
    * import {Series} from "@rapidsai/cudf";
    *
-   * // Float64Series
-   * Series.new([1, 2, 3]).getValue(0) // 1
-   * // StringSeries
-   * Series.new(["foo", "bar", "test"]).getValue(2) // "test"
-   * // Bool8Series
-   * Series.new([false, true, true]).getValue(3) // throws index out of bounds error
+   * // Series<List<Float64>>
+   * Series.new([[1, 2], [3]]).getValue(0) // Series([1, 2])
+   *
+   * // Series<List<Utf8String>>
+   * Series.new([["foo", "bar"], ["test"]]).getValue(1) // Series(["test"])
+   *
+   * // Series<List<Bool8>>
+   * Series.new([[false, true], [true]]).getValue(2) // throws index out of bounds error
    * ```
    */
   getValue(index: number) {
@@ -107,20 +109,21 @@ export class ListSeries<T extends DataType> extends Series<List<T>> {
    * ```typescript
    * import {Series} from "@rapidsai/cudf";
    *
-   * // Float64Series
-   * const a = Series.new([1, 2, 3]);
-   * a.setValue(0, -1) // inplace update [-1, 2, 3]
+   * // Series<List<Float64>>
+   * const a = Series.new([[1, 2], [3]])
+   * a.setValue(0, [-1]) // inplace update -> Series([[-1], [3]])
    *
-   * // StringSeries
-   * const b = Series.new(["foo", "bar", "test"])
-   * b.setValue(1,"test1") // inplace update ["foo", "test1", "test"]
-   * // Bool8Series
-   * const c = Series.new([false, true, true])
-   * c.cetValue(2, false) // inplace update [false, true, false]
+   * // Series<List<Utf8String>>
+   * const b = Series.new([["foo", "bar"], ["test"]])
+   * b.setValue(0, ["test1"]) // inplace update -> Series([["test1"] ["test"]])
+   *
+   * // Series<List<Bool8>>
+   * const c = Series.new([[false, true], [true]])
+   * c.setValue(0, [false]) // inplace update -> Series([[false], [true]])
    * ```
    */
-  setValue(index: number, value: Series<T>): void {
-    this._col = this.scatter(value._col as Column<T>, [index])._col;
+  setValue(index: number, value: T['scalarType'][]|Series<T>): void {
+    this._col = this.scatter(Series.new<T>(<any>value)._col as Column<T>, [index])._col;
   }
 
   /** @ignore */

--- a/modules/cudf/src/series/list.ts
+++ b/modules/cudf/src/series/list.ts
@@ -36,6 +36,7 @@ export class ListSeries<T extends DataType> extends Series<List<T>> {
     throw new Error(`Cast from ${arrow.Type[this.type.typeId]} to ${
       arrow.Type[dataType.typeId]} not implemented`);
   }
+
   /**
    * Series of integer offsets for each list
    * @example
@@ -74,9 +75,52 @@ export class ListSeries<T extends DataType> extends Series<List<T>> {
   // TODO: account for this.offset
   get elements(): Series<T> { return Series.new(this._col.getChild<T>(1)); }
 
-  getValue(index: number): Series<T>|null {
+  /**
+   * Return a value at the specified index to host memory
+   *
+   * @param index the index in this Series to return a value for
+   *
+   * @example
+   * ```typescript
+   * import {Series} from "@rapidsai/cudf";
+   *
+   * // Float64Series
+   * Series.new([1, 2, 3]).getValue(0) // 1
+   * // StringSeries
+   * Series.new(["foo", "bar", "test"]).getValue(2) // "test"
+   * // Bool8Series
+   * Series.new([false, true, true]).getValue(3) // throws index out of bounds error
+   * ```
+   */
+  getValue(index: number) {
     const value = this._col.getValue(index);
     return value === null ? null : Series.new(value);
+  }
+
+  /**
+   * set value at the specified index
+   *
+   * @param index the index in this Series to set a value for
+   * @param value the value to set at `index`
+   *
+   * @example
+   * ```typescript
+   * import {Series} from "@rapidsai/cudf";
+   *
+   * // Float64Series
+   * const a = Series.new([1, 2, 3]);
+   * a.setValue(0, -1) // inplace update [-1, 2, 3]
+   *
+   * // StringSeries
+   * const b = Series.new(["foo", "bar", "test"])
+   * b.setValue(1,"test1") // inplace update ["foo", "test1", "test"]
+   * // Bool8Series
+   * const c = Series.new([false, true, true])
+   * c.cetValue(2, false) // inplace update [false, true, false]
+   * ```
+   */
+  setValue(index: number, value: Series<T>): void {
+    this._col = this.scatter(value._col as Column<T>, [index])._col;
   }
 
   /** @ignore */

--- a/modules/cudf/src/series/numeric.ts
+++ b/modules/cudf/src/series/numeric.ts
@@ -89,10 +89,8 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    *
    * // Float64Series
    * Series.new([1, 2, 3]).getValue(0) // 1
-   * // StringSeries
-   * Series.new(["foo", "bar", "test"]).getValue(2) // "test"
-   * // Bool8Series
-   * Series.new([false, true, true]).getValue(3) // throws index out of bounds error
+   * Series.new([1, 2, 3]).getValue(2) // 3
+   * Series.new([1, 2, 3]).getValue(3) // throws index out of bounds error
    * ```
    */
   getValue(index: number) { return this._col.getValue(index); }
@@ -109,14 +107,7 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    *
    * // Float64Series
    * const a = Series.new([1, 2, 3]);
-   * a.setValue(0, -1) // inplace update [-1, 2, 3]
-   *
-   * // StringSeries
-   * const b = Series.new(["foo", "bar", "test"])
-   * b.setValue(1,"test1") // inplace update ["foo", "test1", "test"]
-   * // Bool8Series
-   * const c = Series.new([false, true, true])
-   * c.cetValue(2, false) // inplace update [false, true, false]
+   * a.setValue(0, -1) // inplace update -> Series([-1, 2, 3])
    * ```
    */
   setValue(index: number, value: T['scalarType']): void {

--- a/modules/cudf/src/series/numeric.ts
+++ b/modules/cudf/src/series/numeric.ts
@@ -79,6 +79,51 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
   }
 
   /**
+   * Return a value at the specified index to host memory
+   *
+   * @param index the index in this Series to return a value for
+   *
+   * @example
+   * ```typescript
+   * import {Series} from "@rapidsai/cudf";
+   *
+   * // Float64Series
+   * Series.new([1, 2, 3]).getValue(0) // 1
+   * // StringSeries
+   * Series.new(["foo", "bar", "test"]).getValue(2) // "test"
+   * // Bool8Series
+   * Series.new([false, true, true]).getValue(3) // throws index out of bounds error
+   * ```
+   */
+  getValue(index: number) { return this._col.getValue(index); }
+
+  /**
+   * set value at the specified index
+   *
+   * @param index the index in this Series to set a value for
+   * @param value the value to set at `index`
+   *
+   * @example
+   * ```typescript
+   * import {Series} from "@rapidsai/cudf";
+   *
+   * // Float64Series
+   * const a = Series.new([1, 2, 3]);
+   * a.setValue(0, -1) // inplace update [-1, 2, 3]
+   *
+   * // StringSeries
+   * const b = Series.new(["foo", "bar", "test"])
+   * b.setValue(1,"test1") // inplace update ["foo", "test1", "test"]
+   * // Bool8Series
+   * const c = Series.new([false, true, true])
+   * c.cetValue(2, false) // inplace update [false, true, false]
+   * ```
+   */
+  setValue(index: number, value: T['scalarType']): void {
+    this._col = this.scatter(value, [index])._col as Column<T>;
+  }
+
+  /**
    * Add this Series and another Series or scalar value.
    *
    * @param rhs The other Series or scalar to add to this Series.

--- a/modules/cudf/src/series/string.ts
+++ b/modules/cudf/src/series/string.ts
@@ -35,6 +35,50 @@ export class StringSeries extends Series<Utf8String> {
     throw new Error(`Cast from ${arrow.Type[this.type.typeId]} to ${
       arrow.Type[dataType.typeId]} not implemented`);
   }
+
+  /**
+   * Return a value at the specified index to host memory
+   *
+   * @param index the index in this Series to return a value for
+   *
+   * @example
+   * ```typescript
+   * import {Series} from "@rapidsai/cudf";
+   *
+   * // Float64Series
+   * Series.new([1, 2, 3]).getValue(0) // 1
+   * // StringSeries
+   * Series.new(["foo", "bar", "test"]).getValue(2) // "test"
+   * // Bool8Series
+   * Series.new([false, true, true]).getValue(3) // throws index out of bounds error
+   * ```
+   */
+  getValue(index: number) { return this._col.getValue(index); }
+
+  /**
+   * set value at the specified index
+   *
+   * @param index the index in this Series to set a value for
+   * @param value the value to set at `index`
+   *
+   * @example
+   * ```typescript
+   * import {Series} from "@rapidsai/cudf";
+   *
+   * // Float64Series
+   * const a = Series.new([1, 2, 3]);
+   * a.setValue(0, -1) // inplace update [-1, 2, 3]
+   *
+   * // StringSeries
+   * const b = Series.new(["foo", "bar", "test"])
+   * b.setValue(1,"test1") // inplace update ["foo", "test1", "test"]
+   * // Bool8Series
+   * const c = Series.new([false, true, true])
+   * c.cetValue(2, false) // inplace update [false, true, false]
+   * ```
+   */
+  setValue(index: number, value: string): void { this._col = this.scatter(value, [index])._col; }
+
   /**
    * Series of integer offsets for each string
    * @example
@@ -47,6 +91,7 @@ export class StringSeries extends Series<Utf8String> {
    */
   // TODO: Account for this.offset
   get offsets() { return Series.new(this._col.getChild<Int32>(0)); }
+
   /**
    * Series containing the utf8 characters of each string
    * @example

--- a/modules/cudf/src/series/string.ts
+++ b/modules/cudf/src/series/string.ts
@@ -45,12 +45,10 @@ export class StringSeries extends Series<Utf8String> {
    * ```typescript
    * import {Series} from "@rapidsai/cudf";
    *
-   * // Float64Series
-   * Series.new([1, 2, 3]).getValue(0) // 1
    * // StringSeries
+   * Series.new(["foo", "bar", "test"]).getValue(0) // "foo"
    * Series.new(["foo", "bar", "test"]).getValue(2) // "test"
-   * // Bool8Series
-   * Series.new([false, true, true]).getValue(3) // throws index out of bounds error
+   * Series.new(["foo", "bar", "test"]).getValue(3) // throws index out of bounds error
    * ```
    */
   getValue(index: number) { return this._col.getValue(index); }
@@ -65,16 +63,9 @@ export class StringSeries extends Series<Utf8String> {
    * ```typescript
    * import {Series} from "@rapidsai/cudf";
    *
-   * // Float64Series
-   * const a = Series.new([1, 2, 3]);
-   * a.setValue(0, -1) // inplace update [-1, 2, 3]
-   *
    * // StringSeries
-   * const b = Series.new(["foo", "bar", "test"])
-   * b.setValue(1,"test1") // inplace update ["foo", "test1", "test"]
-   * // Bool8Series
-   * const c = Series.new([false, true, true])
-   * c.cetValue(2, false) // inplace update [false, true, false]
+   * const a = Series.new(["foo", "bar", "test"])
+   * a.setValue(2, "test1") // inplace update -> Series(["foo", "bar", "test1"])
    * ```
    */
   setValue(index: number, value: string): void { this._col = this.scatter(value, [index])._col; }

--- a/modules/cudf/src/series/struct.ts
+++ b/modules/cudf/src/series/struct.ts
@@ -37,6 +37,7 @@ export class StructSeries<T extends TypeMap> extends Series<Struct<T>> {
     throw new Error(`Cast from ${arrow.Type[this.type.typeId]} to ${
       arrow.Type[dataType.typeId]} not implemented`);
   }
+
   /**
    * Return a child series by name.
    *

--- a/modules/cudf/src/types/dtypes.ts
+++ b/modules/cudf/src/types/dtypes.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as arrow from 'apache-arrow';
+import {Column} from '../column';
 import {TypeMap} from './mappings';
 
 export type FloatingPoint = Float32|Float64;
@@ -105,7 +106,7 @@ export class Utf8String extends arrow.Utf8 {}
 
 export interface List<T extends DataType = any> extends arrow.List<T> {
   childType: T;
-  scalarType: any;
+  scalarType: Column<T>;
 }
 export class List<T extends DataType = any> extends arrow.List<T> {}
 

--- a/modules/cudf/src/types/dtypes.ts
+++ b/modules/cudf/src/types/dtypes.ts
@@ -44,6 +44,7 @@ export class Int32 extends arrow.Int32 {}
 (Int32.prototype as any).BYTES_PER_ELEMENT = 4;
 
 export interface Int64 extends arrow.Int64 {
+  TValue: bigint;
   scalarType: bigint;
   readonly BYTES_PER_ELEMENT: number;
 }
@@ -72,6 +73,7 @@ export class Uint32 extends arrow.Uint32 {}
 (Uint32.prototype as any).BYTES_PER_ELEMENT = 4;
 
 export interface Uint64 extends arrow.Uint64 {
+  TValue: bigint;
   scalarType: bigint;
   readonly BYTES_PER_ELEMENT: number;
 }

--- a/modules/cudf/src/types/dtypes.ts
+++ b/modules/cudf/src/types/dtypes.ts
@@ -105,7 +105,7 @@ export class Utf8String extends arrow.Utf8 {}
 
 export interface List<T extends DataType = any> extends arrow.List<T> {
   childType: T;
-  scalarType: T['scalarType'][];
+  scalarType: any;
 }
 export class List<T extends DataType = any> extends arrow.List<T> {}
 

--- a/modules/cudf/test/series/list-tests.ts
+++ b/modules/cudf/test/series/list-tests.ts
@@ -39,6 +39,12 @@ describe('ListSeries', () => {
     expect(expectedElements).toEqualTypedArray(actualElements);
   };
 
+  test('Can create from JS Arrays', () => {
+    const listOfLists = [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, null]];
+    const col         = Series.new(listOfLists);
+    expect([...col].map((elt) => [...elt!])).toEqual(listOfLists);
+  });
+
   test('Can create from Arrow', () => {
     const vec  = listsOfInt32s([[0, 1, 2], [3, 4, 5]]);
     const ints = vec.getChildAt<arrow.Int32>(0)! as VectorType<arrow.Int32>;

--- a/modules/cudf/test/series/list-tests.ts
+++ b/modules/cudf/test/series/list-tests.ts
@@ -17,7 +17,7 @@
 import '../jest-extensions';
 
 import {setDefaultAllocator} from '@nvidia/cuda';
-import {Int32, List, Series} from '@rapidsai/cudf';
+import {Int32, Int32Series, List, Series} from '@rapidsai/cudf';
 import {CudaMemoryResource, DeviceBuffer} from '@rapidsai/rmm';
 import * as arrow from 'apache-arrow';
 import {VectorType} from 'apache-arrow/interfaces';
@@ -48,17 +48,16 @@ describe('ListSeries', () => {
     validateElements(ints, col.elements);
   });
 
-  // Uncomment after https://github.com/rapidsai/cudf/pull/8071 is merged
-  // test('Can get individual values', () => {
-  //   const vec = listsOfInt32s([[0, 1, 2], [3, 4, 5]]);
-  //   const col = Series.new(vec);
-  //   for (let i = -1; ++i < col.length;) {
-  //     const elt = col.getValue(i);
-  //     expect(elt).not.toBeNull();
-  //     expect(elt).toBeInstanceOf(Int32Series);
-  //     expect([...elt!]).toEqual([...vec.get(i)!]);
-  //   }
-  // });
+  test('Can get individual values', () => {
+    const vec = listsOfInt32s([[0, 1, 2], [3, 4, 5]]);
+    const col = Series.new(vec);
+    for (let i = -1; ++i < col.length;) {
+      const elt = col.getValue(i);
+      expect(elt).not.toBeNull();
+      expect(elt).toBeInstanceOf(Int32Series);
+      expect([...elt!]).toEqual([...vec.get(i)!]);
+    }
+  });
 
   test('Can create a List of Lists from Arrow', () => {
     const vec  = listsOfListsOfInt32s([[[0, 1, 2]], [[3, 4, 5], [7, 8, 9]]]);

--- a/modules/cudf/test/series/list-tests.ts
+++ b/modules/cudf/test/series/list-tests.ts
@@ -48,6 +48,18 @@ describe('ListSeries', () => {
     validateElements(ints, col.elements);
   });
 
+  // Uncomment after https://github.com/rapidsai/cudf/pull/8071 is merged
+  // test('Can get individual values', () => {
+  //   const vec = listsOfInt32s([[0, 1, 2], [3, 4, 5]]);
+  //   const col = Series.new(vec);
+  //   for (let i = -1; ++i < col.length;) {
+  //     const elt = col.getValue(i);
+  //     expect(elt).not.toBeNull();
+  //     expect(elt).toBeInstanceOf(Int32Series);
+  //     expect([...elt!]).toEqual([...vec.get(i)!]);
+  //   }
+  // });
+
   test('Can create a List of Lists from Arrow', () => {
     const vec  = listsOfListsOfInt32s([[[0, 1, 2]], [[3, 4, 5], [7, 8, 9]]]);
     const list = vec.getChildAt<ListOfInt32>(0)! as VectorType<ListOfInt32>;

--- a/modules/cudf/test/series/list-tests.ts
+++ b/modules/cudf/test/series/list-tests.ts
@@ -65,6 +65,15 @@ describe('ListSeries', () => {
     }
   });
 
+  // Uncomment this once libcudf supports scatter w/ list_scalar
+  // test('Can set individual values', () => {
+  //   const listOfLists = [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, null]];
+  //   const col         = Series.new(listOfLists);
+  //   col.setValue(0, [1, 1, 1]);
+  //   expect([...col].map((elt) => [...elt!])).toEqual([[1, 1, 1], [3, 4, 5], [6, 7, 8], [9,
+  //   null]]);
+  // });
+
   test('Can create a List of Lists from Arrow', () => {
     const vec  = listsOfListsOfInt32s([[[0, 1, 2]], [[3, 4, 5], [7, 8, 9]]]);
     const list = vec.getChildAt<ListOfInt32>(0)! as VectorType<ListOfInt32>;


### PR DESCRIPTION
Now that [`cudf::get_element` supports `list_scalar`](https://github.com/rapidsai/cudf/pull/8071), we can add `ListSeries.getValue()`.

* Support creating `ListSeries` from Arrays of JS Arrays
* Move `getValue` and `setValue` to the Series subclasses to make the types happy
* Implement `ListSeries.getValue()`