### PR TITLE
[FEA] Added `isNotNull` and `isNotNaN`

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -294,8 +294,8 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `mul`                |                    |
 | `nans_to_nulls`      | ✅ (`nansToNulls`) |
 | `nlargest`           |                    |
-| `notna`              |                    |
-| `notnull`            |                    |
+| `notna`              |  ✅ (`isNotNaN`)   |
+| `notnull`            |  ✅ (`isNotNull`)  |
 | `nsmallest`          |                    |
 | `one_hot_encoding`   |                    |
 | `partition_by_hash`  |                    |

--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -448,12 +448,12 @@ test('dataframe.isNaN', () => {
   const expected_a = Series.new(a);
   const expected_b = Series.new([true, false, false, true, false]);
   const expected_c = Series.new(c);
-  
+
   expect([...result.get('a')]).toEqual([...expected_a]);
   expect([...result.get('b')]).toEqual([...expected_b]);
   expect([...result.get('c')]).toEqual([...expected_c]);
 });
-  
+
 test('dataframe.isNull', () => {
   const a      = Series.new([0, null, 2, 3, null]);
   const b      = Series.new([NaN, 0, 3, NaN, null]);
@@ -464,6 +464,38 @@ test('dataframe.isNull', () => {
   const expected_a = Series.new({type: new Bool8, data: [false, true, false, false, true]});
   const expected_b = Series.new({type: new Bool8, data: [false, false, false, false, true]});
   const expected_c = Series.new({type: new Bool8, data: [true, true, false, false, false]});
+
+  expect([...result.get('a')]).toEqual([...expected_a]);
+  expect([...result.get('b')]).toEqual([...expected_b]);
+  expect([...result.get('c')]).toEqual([...expected_c]);
+});
+
+test('dataframe.isNotNaN', () => {
+  const a      = Series.new({type: new Float32, data: [0, NaN, 2, NaN, null]});
+  const b      = Series.new({type: new Int32, data: [0, null, 2, 3, null]});
+  const c      = Series.new([null, null, 'foo', 'bar', '']);
+  const df     = new DataFrame({'a': a, 'b': b, 'c': c});
+  const result = df.isNotNaN();
+
+  const expected_a = Series.new([true, false, true, false, true]);
+  const expected_b = Series.new(b);
+  const expected_c = Series.new(c);
+
+  expect([...result.get('a')]).toEqual([...expected_a]);
+  expect([...result.get('b')]).toEqual([...expected_b]);
+  expect([...result.get('c')]).toEqual([...expected_c]);
+});
+
+test('dataframe.isNotNull', () => {
+  const a      = Series.new([null, 1, 2, 3, null]);
+  const b      = Series.new([NaN, 0, 3, NaN, null]);
+  const c      = Series.new(['foo', 'bar', null, null, '']);
+  const df     = new DataFrame({'a': a, 'b': b, 'c': c});
+  const result = df.isNotNull();
+
+  const expected_a = Series.new({type: new Bool8, data: [false, true, true, true, false]});
+  const expected_b = Series.new({type: new Bool8, data: [true, true, true, true, false]});
+  const expected_c = Series.new({type: new Bool8, data: [true, true, false, false, true]});
 
   expect([...result.get('a')]).toEqual([...expected_a]);
   expect([...result.get('b')]).toEqual([...expected_b]);


### PR DESCRIPTION
Quick and easy bindings to write due to https://github.com/rapidsai/node-rapids/pull/189 and https://github.com/rapidsai/node-rapids/pull/188

**Changes**
- Added `isNotNull` to DataFrame
- Added `isNotNaN` to DataFrame
- Added `isNotNull` test to `cudf-data-frame-tests`
- Added `isNotNaN` test to `cudf-data-frame-tests`