### PR TITLE
Added `FloatSeries` `nansToNulls`

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -77,7 +77,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `mod`                |         ✅          |
 | `mode`               |                     |
 | `mul`                |         ✅          |
-| `nans_to_nulls`      |                     |
+| `nans_to_nulls`      |  ✅ (`nansToNulls`) |
 | `ne`                 |         ✅          |
 | `nlargest`           |                     |
 | `notna`              |  ✅ (`isNotNull`)   |

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -184,7 +184,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `map`                |                     |                     |                     |
 | `mask`               |                     |                     |                     |
 | `memory_usage`       |                     |                     |                     |
-| `nans_to_nulls`      |                     |                     |                     |
+| `nans_to_nulls`      |  ✅ (`nansToNulls`) |  ✅ (`nansToNulls`) |  ✅ (`nansToNulls`) |
 | `notna`              |  ✅ (`isNotNull`)   |  ✅ (`isNotNull`)   |  ✅ (`isNotNull`)   |
 | `notnull`            |  ✅ (`isNotNull`)   |  ✅ (`isNotNull`)   |  ✅ (`isNotNull`)   |
 | `nunique`            |                     |                     |                     |

--- a/modules/cudf/test/series/unaryop/float32-tests.ts
+++ b/modules/cudf/test/series/unaryop/float32-tests.ts
@@ -63,6 +63,10 @@ describe('Series unaryops (Float32)', () => {
     const actual = makeTestData([NaN, 2.5, 5]).isNotNaN();
     expect([...actual]).toEqual([false, true, true]);
   });
+  test('Series.nansToNulls', () => {
+    const actual = makeTestData([NaN, 2.5, 5]).nansToNulls();
+    expect([...actual]).toEqual([null, 2.5, 5]);
+  });
   test('Series.rint', () => {
     const actual = makeTestData([NaN, 2.5, 5]).rint();
     expect([...actual]).toEqual([NaN, 2, 5]);

--- a/modules/cudf/test/series/unaryop/float64-tests.ts
+++ b/modules/cudf/test/series/unaryop/float64-tests.ts
@@ -63,6 +63,10 @@ describe('Series unaryops (Float64)', () => {
     const actual = makeTestData([NaN, 2.5, 5]).isNotNaN();
     expect([...actual]).toEqual([false, true, true]);
   });
+  test('Series.nansToNulls', () => {
+    const actual = makeTestData([NaN, 2.5, 5]).nansToNulls();
+    expect([...actual]).toEqual([null, 2.5, 5]);
+  });
   test('Series.rint', () => {
     const actual = makeTestData([NaN, 2.5, 5]).rint();
     expect([...actual]).toEqual([NaN, 2, 5]);


### PR DESCRIPTION
Binding already existed, updating `BINDINGS.md` and adding tests. `DataFrame` implementation already handled.

I've marked off `StringSeries`, `ListSeries`, as having `nansToNulls` completed since this binding should be only implemented on Series of type`FloatSeries`.

**Changes**
- Added `nansToNulls` to `BINDINGS.md`
- Added Float32 & Float64 `nansToNulls` test