### PR TITLE
[FIX] make GraphCOO `numNodes` and `numEdges` functions instead of getters

### DIFF
--- a/modules/cugraph/src/addon.ts
+++ b/modules/cugraph/src/addon.ts
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable @typescript-eslint/no-redeclare */
+
 import {addon as CUDA} from '@nvidia/cuda';
 import {loadNativeModule} from '@rapidsai/core';
 import {addon as CUDF} from '@rapidsai/cudf';
 import {addon as RMM} from '@rapidsai/rmm';
-import {GraphCOOConstructor} from './graph_coo';
 
-export const {GraphCOO} = loadNativeModule<{
-  GraphCOO: GraphCOOConstructor,  //
-}>(module, 'node_cugraph', init => init(CUDA, CUDF, RMM));
+export const {GraphCOO, _cpp_exports} = loadNativeModule<typeof import('./node_cugraph')>(
+  module, 'node_cugraph', init => init(CUDA, CUDF, RMM));
+
+export type GraphCOO = import('./node_cugraph').GraphCOO;

--- a/modules/cugraph/src/index.ts
+++ b/modules/cugraph/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,4 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './graph_coo';
+export * as addon from './addon';
+
+export {GraphCOO} from './addon';

--- a/modules/cugraph/src/node_cugraph.ts
+++ b/modules/cugraph/src/node_cugraph.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION.
+// Copyright (c) 2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Column, Int32} from '@rapidsai/cudf';
+import {Column, FloatingPoint, Integral} from '@rapidsai/cudf';
 import {DeviceBuffer, MemoryResource} from '@rapidsai/rmm';
 
-export interface GraphCOOConstructor {
-  readonly prototype: GraphCOO;
-  new(src: Column<Int32>, dst: Column<Int32>, options?: {directedEdges?: boolean}): GraphCOO;
-}
+/** @ignore */
+export declare const _cpp_exports: any;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-interface GraphCOO {
-  readonly numEdges: number;
-  readonly numNodes: number;
+export declare class GraphCOO {
+  constructor(src: Column<Integral|FloatingPoint>,
+              dst: Column<Integral|FloatingPoint>,
+              options?: {directedEdges?: boolean});
+
+  numEdges(): number;
+  numNodes(): number;
 
   forceAtlas2(options: {
     memoryResource?: MemoryResource,
@@ -41,5 +42,3 @@ interface GraphCOO {
     verbose?: boolean,
   }): DeviceBuffer;
 }
-
-export {GraphCOO} from './addon';

--- a/modules/cugraph/src/node_cugraph/graph_coo.hpp
+++ b/modules/cugraph/src/node_cugraph/graph_coo.hpp
@@ -90,8 +90,8 @@ struct GraphCOO : public EnvLocalObjectWrap<GraphCOO> {
   cudf::size_type node_count_{};
   bool node_count_computed_{false};
 
-  Napi::Reference<Column::wrapper_t> src_{};
-  Napi::Reference<Column::wrapper_t> dst_{};
+  Napi::Reference<Column::wrapper_t> src_;
+  Napi::Reference<Column::wrapper_t> dst_;
 };
 
 }  // namespace nv

--- a/modules/demo/graph/src/loader.js
+++ b/modules/demo/graph/src/loader.js
@@ -188,7 +188,7 @@ export default async function* loadGraphData(props = {}) {
       }
     }
 
-    const n = graph.numNodes;
+    const n = graph.numNodes();
 
     // If new nodes, update existing positions
     if (positions && positions.length < (n * 2)) {
@@ -267,8 +267,8 @@ function promiseSubject() {
  * @param {*} graph
  */
 function createGraphRenderProps(nodes, edges, graph) {
-  const numNodes = graph.numNodes;
-  const numEdges = graph.numEdges;
+  const numNodes = graph.numNodes();
+  const numEdges = graph.numEdges();
   return {
     numNodes, numEdges, nodeRadiusScale: 1 / 75,
     // nodeRadiusScale: 1/255,


### PR DESCRIPTION
Fixes node REPL crashes reported in https://github.com/nodejs/node-addon-api/issues/1000.