### PR TITLE
Added `series` `.countNonNulls()`

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -28,7 +28,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `copy`               |                     |
 | `corr`               |                     |
 | `cos`                |         ✅          |
-| `count`              |                     |
+| `count`              |         ✅          |
 | `cov`                |                     |
 | `cummax`             |                     |
 | `cummin`             |                     |

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -156,7 +156,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `astype`             |                     |                     |                     |
 | `clip`               |                     |                     |                     |
 | `copy`               |                     |                     |                     |
-| `count`              |                     |                     |                     |
+| `count`              |✅ (`countNonNulls`) |✅ (`countNonNulls`) |✅ (`countNonNulls`) |
 | `describe`           |                     |                     |                     |
 | `diff`               |                     |                     |                     |
 | `digitize`           |                     |                     |                     |

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -28,7 +28,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `copy`               |                     |
 | `corr`               |                     |
 | `cos`                |         ✅          |
-| `count`              |         ✅          |
+| `count`              |✅ (`countNonNulls`) |
 | `cov`                |                     |
 | `cummax`             |                     |
 | `cummin`             |                     |

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -361,11 +361,11 @@ export class AbstractSeries<T extends DataType = any> {
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
    *
-   * Series.new([1, 2, 3]).count(); // 3
-   * Series.new([1, null, 3]).count(); // 2
+   * Series.new([1, 2, 3]).countNonNulls(); // 3
+   * Series.new([1, null, 3]).countNonNulls(); // 2
    * ```
    */
-  count(): number { return this._col.length - this._col.nullCount; }
+  countNonNulls(): number { return this._col.length - this._col.nullCount; }
 
   /**
    * Fills a range of elements in a column out-of-place with a scalar value.

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -355,6 +355,8 @@ export class AbstractSeries<T extends DataType = any> {
   /**
    * Return the number of non-null elements in the Series.
    *
+   * @returns The number of non-null elements
+   *
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -353,6 +353,19 @@ export class AbstractSeries<T extends DataType = any> {
   get numChildren() { return this._col.numChildren; }
 
   /**
+   * Return the number of non-null elements in the Series.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([1, 2, 3]).count(); // 3
+   * Series.new([1, null, 3]).count(); // 2
+   * ```
+   */
+  count(): number { return this._col.length - this._col.nullCount; }
+
+  /**
    * Fills a range of elements in a column out-of-place with a scalar value.
    *
    * @param begin The starting index of the fill range (inclusive).

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -391,6 +391,13 @@ test('FloatSeries.nansToNulls', () => {
   expect(col.nullCount).toEqual(0);
 });
 
+test('Series.count', () => {
+  expect(Series.new([]).count()).toEqual(0);
+  expect(Series.new([0, 1, null, 3, 4, null, 6, null]).count()).toEqual(5);
+  expect(Series.new(['foo', null, 'bar']).count()).toEqual(2);
+  expect(Series.new([NaN, null, 10, 15, 17, null]).count()).toEqual(4);
+});
+
 describe.each([new Int32, new Float32, new Float64])('Series.sequence({type=%p,, ...})', (typ) => {
   test('no step', () => {
     const col = Series.sequence({type: typ, size: 10, init: 0});

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -391,11 +391,11 @@ test('FloatSeries.nansToNulls', () => {
   expect(col.nullCount).toEqual(0);
 });
 
-test('Series.count', () => {
-  expect(Series.new([]).count()).toEqual(0);
-  expect(Series.new([0, 1, null, 3, 4, null, 6, null]).count()).toEqual(5);
-  expect(Series.new(['foo', null, 'bar']).count()).toEqual(2);
-  expect(Series.new([NaN, null, 10, 15, 17, null]).count()).toEqual(4);
+test('Series.countNonNulls', () => {
+  expect(Series.new([]).countNonNulls()).toEqual(0);
+  expect(Series.new([0, 1, null, 3, 4, null, 6, null]).countNonNulls()).toEqual(5);
+  expect(Series.new(['foo', null, 'bar']).countNonNulls()).toEqual(2);
+  expect(Series.new([NaN, null, 10, 15, 17, null]).countNonNulls()).toEqual(4);
 });
 
 describe.each([new Int32, new Float32, new Float64])('Series.sequence({type=%p,, ...})', (typ) => {


### PR DESCRIPTION
https://docs.rapids.ai/api/cudf/nightly/api.html#cudf.core.series.Series.count

Similar to other `{x}Null` methods. I think it makes sense to specify `NonNulls` as we do it with other bindings such as `dropNulls`.

**Changes**
- Added `countNonNulls()` to `series`
- Added `countNonNulls()` tests to `cudf-series-test`

