### PR TITLE
Added `series` `countNonNulls`

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -28,7 +28,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `copy`               |                     |
 | `corr`               |                     |
 | `cos`                |         ✅          |
-| `count`              |                     |
+| `count`              |✅ (`countNonNulls`) |
 | `cov`                |                     |
 | `cummax`             |                     |
 | `cummin`             |                     |
@@ -156,7 +156,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `astype`             |                     |                     |                     |
 | `clip`               |                     |                     |                     |
 | `copy`               |                     |                     |                     |
-| `count`              |                     |                     |                     |
+| `count`              |✅ (`countNonNulls`) |✅ (`countNonNulls`) |✅ (`countNonNulls`) |
 | `describe`           |                     |                     |                     |
 | `diff`               |                     |                     |                     |
 | `digitize`           |                     |                     |                     |

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -385,6 +385,21 @@ export class AbstractSeries<T extends DataType = any> {
   get numChildren() { return this._col.numChildren; }
 
   /**
+   * Return the number of non-null elements in the Series.
+   *
+   * @returns The number of non-null elements
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * Series.new([1, 2, 3]).countNonNulls(); // 3
+   * Series.new([1, null, 3]).countNonNulls(); // 2
+   * ```
+   */
+  countNonNulls(): number { return this._col.length - this._col.nullCount; }
+
+  /**
    * Fills a range of elements in a column out-of-place with a scalar value.
    *
    * @param begin The starting index of the fill range (inclusive).

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -391,6 +391,16 @@ test('FloatSeries.dropNaNs (drop NaN values only)', () => {
   expect([...result]).toEqual(expected);
 });
 
+test('Series.countNonNulls', () => {
+  const twoNonNulls  = Series.new(['foo', null, 'bar']);
+  const fourNonNulls = Series.new([NaN, null, 10, 15, 17, null]);
+  const fiveNonNulls = Series.new([0, 1, null, 3, 4, null, 6, null]);
+
+  expect(twoNonNulls.countNonNulls()).toEqual(2);
+  expect(fourNonNulls.countNonNulls()).toEqual(4);
+  expect(fiveNonNulls.countNonNulls()).toEqual(5);
+});
+
 test('FloatSeries.nansToNulls', () => {
   const col = Series.new({type: new Float32, data: new Float32Buffer([1, 3, NaN, 4, 2, 0])});
 


### PR DESCRIPTION
This previously would check `NaN` and `null`, but, I think it's reasonable just to implement this for `nulls` (as we did for `replaceNulls` for example).

https://docs.rapids.ai/api/cudf/nightly/api.html#cudf.core.series.Series.count