### PR TITLE
Update Bindings Table

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -135,8 +135,8 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `to_pandas`          |                     |
 | `to_string`          |                     |
 | `truediv`            |         ✅          |
-| `unique`             |                     |
-| `value_counts`       |                     |
+| `unique`             |         ✅          |
+| `value_counts`       |         ✅          |
 | `values_to_string`   |                     |
 | `var`                |         ✅          |
 | `where`              |                     |

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -220,8 +220,8 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `to_json`            |                     |                     |                     |
 | `to_pandas`          |                     |                     |                     |
 | `to_string`          |                     |                     |                     |
-| `unique`             |                     |                     |                     |
-| `value_counts`       |                     |                     |                     |
+| `unique`             |         ✅          |          ✅         |         ✅          |
+| `value_counts`       |         ✅          |          ✅         |         ✅          |
 | `values_to_string`   |                     |                     |                     |
 | `where`              |                     |                     |                     |
 | `get_json_object`    |                     | ✅ (`getJSONObject`)|                     |


### PR DESCRIPTION
This PR updates the binding table to check off `Series.unique` and `Series.value_counts`, which were done in #143.