### PR TITLE
Add closing bracket in `cudf-data-frame-tests.ts`

### DIFF
--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -540,7 +540,7 @@ describe('dataframe unaryops', () => {
 
   test('dataframe.log', () => {
     const result = df.log();
-    expect([...result.get('a')]).toEqual([-2147483648, -2147483648, 1);
+    expect([...result.get('a')]).toEqual([-2147483648, -2147483648, 1]);
     expect([...result.get('b')]).toEqual([0, 0, 1]);
     expect([...result.get('c')]).toEqual([...c]);
     expect([...result.get('d')]).toEqual([...d.log()]);


### PR DESCRIPTION
This PR adds a missing closing bracket to the `cudf-data-frame-tests.ts` file which was preventing the docs job from running as shown in the log below.

https://github.com/rapidsai/node-rapids/runs/2634700588