### PR TITLE
[FIX] Update default `CUDA_VERSION` and `LINUX_VERSION`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,7 +7,7 @@ UID=1000
 PARALLEL_LEVEL=8
 
 # `nvidia/cudagl` base image CUDA version
-CUDA_VERSION=11.0
+CUDA_VERSION=11.2.2
 
 # `nvidia/cudagl` base image Ubuntu version
 LINUX_VERSION=ubuntu20.04

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,13 +32,13 @@ services:
 
   runtime:
     <<: *common_service_settings
-    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.0}-runtime-${LINUX_VERSION:-ubuntu18.04}-amd64
+    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.2.2}-runtime-${LINUX_VERSION:-ubuntu20.04}-amd64
     build:
       <<: *common_build_settings
       dockerfile: dockerfiles/runtime.Dockerfile
       args:
         <<: *common_build_args
-        BASE_IMAGE: nvidia/cudagl:${CUDA_VERSION:-11.0}-runtime-${LINUX_VERSION:-ubuntu18.04}
+        BASE_IMAGE: nvidia/cudagl:${CUDA_VERSION:-11.2.2}-runtime-${LINUX_VERSION:-ubuntu20.04}
     volumes:
       - &workdir "${PWD}:${PWD}:rw"
       - &etc_fonts "/etc/fonts:/etc/fonts:ro"
@@ -48,7 +48,7 @@ services:
 
   devel:
     <<: *common_service_settings
-    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.0}-devel-${LINUX_VERSION:-ubuntu18.04}-amd64
+    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.2.2}-devel-${LINUX_VERSION:-ubuntu20.04}-amd64
     build:
       <<: *common_build_settings
       dockerfile: dockerfiles/devel.Dockerfile
@@ -58,7 +58,7 @@ services:
         PARALLEL_LEVEL: "${PARALLEL_LEVEL:-}"
         CMAKE_VERSION: "${CMAKE_VERSION:-3.20.2}"
         CCACHE_VERSION: "${CCACHE_VERSION:-4.1}"
-        BASE_IMAGE: nvidia/cudagl:${CUDA_VERSION:-11.0}-devel-${LINUX_VERSION:-ubuntu18.04}
+        BASE_IMAGE: nvidia/cudagl:${CUDA_VERSION:-11.2.2}-devel-${LINUX_VERSION:-ubuntu20.04}
     environment:
       <<: *common_environment_variables
       DOCKER_WORKDIR: "${PWD}"
@@ -80,12 +80,12 @@ services:
 
   nteract:
     <<: *common_service_settings
-    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.0}-nteract-${LINUX_VERSION:-ubuntu18.04}-amd64
+    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.2.2}-nteract-${LINUX_VERSION:-ubuntu20.04}-amd64
     build:
       <<: *common_build_settings
       dockerfile: dockerfiles/nteract.Dockerfile
       args:
-        BASE_IMAGE: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.0}-devel-${LINUX_VERSION:-ubuntu18.04}-amd64
+        BASE_IMAGE: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.2.2}-devel-${LINUX_VERSION:-ubuntu20.04}-amd64
     environment:
       <<: *common_environment_variables
       DOCKER_WORKDIR: "${PWD}"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -44,7 +44,7 @@ You can also build and run on a properly configured Linux installation without d
 
 ### Dependencies
 
-We assume you have [node, npm](https://github.com/nvm-sh/nvm#installing-and-updating), [yarn](https://yarnpkg.com/getting-started/install), [CMake v3.20.2+](https://cmake.org/), and [CUDA Toolkit 11.0+](https://developer.nvidia.com/cuda-downloads) installed.
+We assume you have [node, npm](https://github.com/nvm-sh/nvm#installing-and-updating), [yarn](https://yarnpkg.com/getting-started/install), [CMake v3.20.2+](https://cmake.org/), and [CUDA Toolkit 11.2+](https://developer.nvidia.com/cuda-downloads) installed.
 
 <details>
 <summary>Click here to see Ubuntu 16.04+ CMake installation commands:</summary>

--- a/modules/core/cmake/Modules/ConfigureCUGRAPH.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUGRAPH.cmake
@@ -34,9 +34,6 @@ function(find_and_configure_cugraph VERSION)
         set(BUILD_TESTS OFF)
         set(BUILD_BENCHMARKS OFF)
 
-        set(NCCL_LIBRARY "/usr/local/cuda/lib64/libnccl.so")
-        set(NCCL_INCLUDE_DIR "/usr/local/cuda/include")
-
         if(${VERSION} MATCHES [=[([0-9]+)\.([0-9]+)\.([0-9]+)]=])
             set(MAJOR_AND_MINOR "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
         else()
@@ -45,10 +42,8 @@ function(find_and_configure_cugraph VERSION)
 
         CPMFindPackage(NAME     cugraph
             VERSION             ${VERSION}
-            # GIT_REPOSITORY      https://github.com/rapidsai/cugraph.git
-            # GIT_TAG             branch-${MAJOR_AND_MINOR}
-            GIT_REPOSITORY      https://github.com/trxcllnt/cugraph.git
-            GIT_TAG             use_rapids_cmake
+            GIT_REPOSITORY      https://github.com/rapidsai/cugraph.git
+            GIT_TAG             branch-${MAJOR_AND_MINOR}
             GIT_SHALLOW         TRUE
             UPDATE_DISCONNECTED FALSE
             SOURCE_SUBDIR       cpp

--- a/modules/cugraph/src/layout/force_atlas2.cpp
+++ b/modules/cugraph/src/layout/force_atlas2.cpp
@@ -68,9 +68,11 @@ Napi::Value GraphCOO::force_atlas2(Napi::CallbackInfo const &info) {
                                num_nodes() * 2 * sizeof(float), rmm::cuda_stream_default, mr));
   }(options.Get("positions"));
 
-  auto graph = this->view();
+  auto graph  = this->view();
+  auto handle = std::make_unique<raft::handle_t>();
 
-  cugraph::force_atlas2(graph,
+  cugraph::force_atlas2(*handle,
+                        graph,
                         reinterpret_cast<float *>(positions->data()),
                         max_iter,
                         x_start,


### PR DESCRIPTION
* Use main cuGraph fork again now that https://github.com/rapidsai/cugraph/pull/1585 is merged.
* Update default `CUDA_VERSION` to 11.2.2 and `LINUX_VERSION` to ubuntu20.04.

These new defaults should work around container NCCL install path weirdness.