### PR TITLE
Add `dropDuplicates` to `Series` and `DataFrame`

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -8,357 +8,357 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 
 #### Numeric Series
 
-| cuDF                 |     node-rapids     |
-| -------------------- | :-----------------: |
-| `abs`                |         ✅          |
-| `acos`               |         ✅          |
-| `add`                |         ✅          |
-| `all`                |         ✅          |
-| `any`                |         ✅          |
-| `append`             |    ✅ (`concat`)    |
-| `applymap`           |                     |
-| `argsort`            |                     |
-| `as_index`           |                     |
-| `as_mask`            |                     |
-| `asin`               |         ✅          |
-| `astype`             |     ✅ (`cast`)     |
-| `atan`               |         ✅          |
-| `ceil`               |         ✅          |
-| `clip`               |                     |
-| `copy`               |                     |
-| `corr`               |                     |
-| `cos`                |         ✅          |
-| `count`              |✅ (`countNonNulls`) |
-| `cov`                |                     |
-| `cummax`             |                     |
-| `cummin`             |                     |
-| `cumprod`            |                     |
-| `cumsum`             |                     |
-| `describe`           |                     |
-| `diff`               |                     |
-| `digitize`           |                     |
-| `drop_duplicates`    |                     |
-| `dropna`             |  ✅ (`dropNulls`)   |
-| `eq`                 |         ✅          |
-| `equals`             |                     |
-| `exp`                |         ✅          |
-| `factorize`          |                     |
-| `fillna`             | ✅ (`replaceNulls`) |
-| `floor`              |         ✅          |
-| `floordiv`           |         ✅          |
-| `from_arrow`         |                     |
-| `from_categorical`   |                     |
-| `from_masked_array`  |                     |
-| `from_pandas`        |                     |
-| `ge`                 |         ✅          |
-| `groupby`            |                     |
-| `gt`                 |         ✅          |
-| `hash_encode`        |                     |
-| `hash_values`        |                     |
-| `head`               |                     |
-| `interleave_columns` |                     |
-| `isin`               |                     |
-| `isna`               |    ✅ (`isNull`)    |
-| `isnull`             |         ✅          |
-| `keys`               |                     |
-| `kurt`               |                     |
-| `kurtosis`           |                     |
-| `label_encoding`     |                     |
-| `le`                 |         ✅          |
-| `log`                |         ✅          |
-| `lt`                 |         ✅          |
-| `map`                |                     |
-| `mask`               |                     |
-| `max`                |         ✅          |
-| `mean`               |         ✅          |
-| `median`             |         ✅          |
-| `memory_usage`       |                     |
-| `min`                |         ✅          |
-| `mod`                |         ✅          |
-| `mode`               |                     |
-| `mul`                |         ✅          |
-| `nans_to_nulls`      |  ✅ (`nansToNulls`) |
-| `ne`                 |         ✅          |
-| `nlargest`           |                     |
-| `notna`              |  ✅ (`isNotNull`)   |
-| `notnull`            |  ✅ (`isNotNull`)   |
-| `nsmallest`          |                     |
-| `nunique`            |         ✅          |
-| `one_hot_encoding`   |                     |
-| `pipe`               |                     |
-| `pow`                |         ✅          |
-| `prod`               |                     |
-| `product`            |         ✅          |
-| `quantile`           |         ✅          |
-| `radd`               |                     |
-| `rank`               |                     |
-| `reindex`            |                     |
-| `rename`             |                     |
-| `repeat`             |                     |
-| `replace`            |                     |
-| `reset_index`        |                     |
-| `reverse`            |                     |
-| `rfloordiv`          |                     |
-| `rmod`               |                     |
-| `rmul`               |                     |
-| `rolling`            |                     |
-| `round`              |                     |
-| `rpow`               |                     |
-| `rsub`               |                     |
-| `rtruediv`           |                     |
-| `sample`             |                     |
-| `scale`              |                     |
-| `scatter_by_map`     |                     |
-| `searchsorted`       |                     |
-| `set_index`          |                     |
-| `set_mask`           |                     |
-| `shift`              |                     |
-| `sin`                |         ✅          |
-| `skew`               |                     |
-| `sort_index`         |                     |
-| `sort_values`        |                     |
-| `sqrt`               |         ✅          |
-| `std`                |         ✅          |
-| `sub`                |         ✅          |
-| `sum`                |         ✅          |
-| `tail`               |                     |
-| `take`               |    ✅ (`gather`)    |
-| `tan`                |         ✅          |
-| `tile`               |                     |
-| `to_array`           |                     |
-| `to_arrow`           |                     |
-| `to_dlpack`          |                     |
-| `to_frame`           |                     |
-| `to_gpu_array`       |                     |
-| `to_hdf`             |                     |
-| `to_json`            |                     |
-| `to_pandas`          |                     |
-| `to_string`          |                     |
-| `truediv`            |         ✅          |
-| `unique`             |         ✅          |
-| `value_counts`       |         ✅          |
-| `values_to_string`   |                     |
-| `var`                |         ✅          |
-| `where`              |                     |
+| cuDF                 |      node-rapids      |
+| -------------------- | :-------------------: |
+| `abs`                |          ✅           |
+| `acos`               |          ✅           |
+| `add`                |          ✅           |
+| `all`                |          ✅           |
+| `any`                |          ✅           |
+| `append`             |     ✅ (`concat`)     |
+| `applymap`           |                       |
+| `argsort`            |                       |
+| `as_index`           |                       |
+| `as_mask`            |                       |
+| `asin`               |          ✅           |
+| `astype`             |      ✅ (`cast`)      |
+| `atan`               |          ✅           |
+| `ceil`               |          ✅           |
+| `clip`               |                       |
+| `copy`               |                       |
+| `corr`               |                       |
+| `cos`                |          ✅           |
+| `count`              | ✅ (`countNonNulls`)  |
+| `cov`                |                       |
+| `cummax`             |                       |
+| `cummin`             |                       |
+| `cumprod`            |                       |
+| `cumsum`             |                       |
+| `describe`           |                       |
+| `diff`               |                       |
+| `digitize`           |                       |
+| `drop_duplicates`    | ✅ (`dropDuplicates`) |
+| `dropna`             |   ✅ (`dropNulls`)    |
+| `eq`                 |          ✅           |
+| `equals`             |                       |
+| `exp`                |          ✅           |
+| `factorize`          |                       |
+| `fillna`             |  ✅ (`replaceNulls`)  |
+| `floor`              |          ✅           |
+| `floordiv`           |          ✅           |
+| `from_arrow`         |                       |
+| `from_categorical`   |                       |
+| `from_masked_array`  |                       |
+| `from_pandas`        |                       |
+| `ge`                 |          ✅           |
+| `groupby`            |                       |
+| `gt`                 |          ✅           |
+| `hash_encode`        |                       |
+| `hash_values`        |                       |
+| `head`               |                       |
+| `interleave_columns` |                       |
+| `isin`               |                       |
+| `isna`               |     ✅ (`isNull`)     |
+| `isnull`             |          ✅           |
+| `keys`               |                       |
+| `kurt`               |                       |
+| `kurtosis`           |                       |
+| `label_encoding`     |                       |
+| `le`                 |          ✅           |
+| `log`                |          ✅           |
+| `lt`                 |          ✅           |
+| `map`                |                       |
+| `mask`               |                       |
+| `max`                |          ✅           |
+| `mean`               |          ✅           |
+| `median`             |          ✅           |
+| `memory_usage`       |                       |
+| `min`                |          ✅           |
+| `mod`                |          ✅           |
+| `mode`               |                       |
+| `mul`                |          ✅           |
+| `nans_to_nulls`      |  ✅ (`nansToNulls`)   |
+| `ne`                 |          ✅           |
+| `nlargest`           |                       |
+| `notna`              |   ✅ (`isNotNull`)    |
+| `notnull`            |   ✅ (`isNotNull`)    |
+| `nsmallest`          |                       |
+| `nunique`            |          ✅           |
+| `one_hot_encoding`   |                       |
+| `pipe`               |                       |
+| `pow`                |          ✅           |
+| `prod`               |                       |
+| `product`            |          ✅           |
+| `quantile`           |          ✅           |
+| `radd`               |                       |
+| `rank`               |                       |
+| `reindex`            |                       |
+| `rename`             |                       |
+| `repeat`             |                       |
+| `replace`            |                       |
+| `reset_index`        |                       |
+| `reverse`            |                       |
+| `rfloordiv`          |                       |
+| `rmod`               |                       |
+| `rmul`               |                       |
+| `rolling`            |                       |
+| `round`              |                       |
+| `rpow`               |                       |
+| `rsub`               |                       |
+| `rtruediv`           |                       |
+| `sample`             |                       |
+| `scale`              |                       |
+| `scatter_by_map`     |                       |
+| `searchsorted`       |                       |
+| `set_index`          |                       |
+| `set_mask`           |                       |
+| `shift`              |                       |
+| `sin`                |          ✅           |
+| `skew`               |                       |
+| `sort_index`         |                       |
+| `sort_values`        |                       |
+| `sqrt`               |          ✅           |
+| `std`                |          ✅           |
+| `sub`                |          ✅           |
+| `sum`                |          ✅           |
+| `tail`               |                       |
+| `take`               |     ✅ (`gather`)     |
+| `tan`                |          ✅           |
+| `tile`               |                       |
+| `to_array`           |                       |
+| `to_arrow`           |                       |
+| `to_dlpack`          |                       |
+| `to_frame`           |                       |
+| `to_gpu_array`       |                       |
+| `to_hdf`             |                       |
+| `to_json`            |                       |
+| `to_pandas`          |                       |
+| `to_string`          |                       |
+| `truediv`            |          ✅           |
+| `unique`             |          ✅           |
+| `value_counts`       |          ✅           |
+| `values_to_string`   |                       |
+| `var`                |          ✅           |
+| `where`              |                       |
 
 #### List, String, Struct Series
 
-| cuDF                 |     List Series     |    String Series    |    Struct Series    |
-| -------------------- | :-----------------: | :-----------------: | :-----------------: |
-| `add`                |                     |                     |                     |
-| `all`                |         ✅          |         ✅          |         ✅          |
-| `any`                |         ✅          |         ✅          |         ✅          |
-| `append`             |    ✅ (`concat`)    |    ✅ (`concat`)    |    ✅ (`concat`)    |
-| `applymap`           |                     |                     |                     |
-| `argsort`            |                     |                     |                     |
-| `as_index`           |                     |                     |                     |
-| `as_mask`            |                     |                     |                     |
-| `astype`             |     ✅ (`cast`)     |     ✅ (`cast`)     |     ✅ (`cast`)     |
-| `clip`               |                     |                     |                     |
-| `copy`               |                     |                     |                     |
-| `count`              |✅ (`countNonNulls`) |✅ (`countNonNulls`) |✅ (`countNonNulls`) |
-| `describe`           |                     |                     |                     |
-| `diff`               |                     |                     |                     |
-| `digitize`           |                     |                     |                     |
-| `drop_duplicates`    |                     |                     |                     |
-| `dropna`             |  ✅ (`dropNulls`)   |  ✅ (`dropNulls`)   |  ✅ (`dropNulls`)   |
-| `equals`             |                     |                     |                     |
-| `factorize`          |                     |                     |                     |
-| `fillna`             | ✅ (`replaceNulls`) | ✅ (`replaceNulls`) | ✅ (`replaceNulls`) |
-| `from_arrow`         |                     |                     |                     |
-| `from_categorical`   |                     |                     |                     |
-| `from_masked_array`  |                     |                     |                     |
-| `from_pandas`        |                     |                     |                     |
-| `groupby`            |                     |                     |                     |
-| `hash_encode`        |                     |                     |                     |
-| `hash_values`        |                     |                     |                     |
-| `head`               |                     |                     |                     |
-| `interleave_columns` |                     |                     |                     |
-| `isin`               |                     |                     |                     |
-| `isna`               |    ✅ (`isNull`)    |    ✅ (`isNull`)    |    ✅ (`isNull`)    |
-| `isnull`             |         ✅          |         ✅          |         ✅          |
-| `keys`               |                     |                     |                     |
-| `kurt`               |                     |                     |                     |
-| `kurtosis`           |                     |                     |                     |
-| `label_encoding`     |                     |                     |                     |
-| `map`                |                     |                     |                     |
-| `mask`               |                     |                     |                     |
-| `memory_usage`       |                     |                     |                     |
-| `nans_to_nulls`      |  ✅ (`nansToNulls`) |  ✅ (`nansToNulls`) |  ✅ (`nansToNulls`) |
-| `notna`              |  ✅ (`isNotNull`)   |  ✅ (`isNotNull`)   |  ✅ (`isNotNull`)   |
-| `notnull`            |  ✅ (`isNotNull`)   |  ✅ (`isNotNull`)   |  ✅ (`isNotNull`)   |
-| `nunique`            |                     |                     |                     |
-| `one_hot_encoding`   |                     |                     |                     |
-| `pipe`               |                     |                     |                     |
-| `quantile`           |                     |                     |                     |
-| `rank`               |                     |                     |                     |
-| `reindex`            |                     |                     |                     |
-| `rename`             |                     |                     |                     |
-| `repeat`             |                     |                     |                     |
-| `replace`            |                     |                     |                     |
-| `reset_index`        |                     |                     |                     |
-| `reverse`            |                     |                     |                     |
-| `rolling`            |                     |                     |                     |
-| `sample`             |                     |                     |                     |
-| `scatter_by_map`     |                     |                     |                     |
-| `searchsorted`       |                     |                     |                     |
-| `set_index`          |                     |                     |                     |
-| `set_mask`           |                     |                     |                     |
-| `shift`              |                     |                     |                     |
-| `skew`               |                     |                     |                     |
-| `sort_index`         |                     |                     |                     |
-| `sort_values`        |                     |                     |                     |
-| `tail`               |                     |                     |                     |
-| `take`               |    ✅ (`gather`)    |    ✅ (`gather`)    |    ✅ (`gather`)    |
-| `tile`               |                     |                     |                     |
-| `to_array`           |                     |                     |                     |
-| `to_arrow`           |                     |                     |                     |
-| `to_dlpack`          |                     |                     |                     |
-| `to_frame`           |                     |                     |                     |
-| `to_gpu_array`       |                     |                     |                     |
-| `to_hdf`             |                     |                     |                     |
-| `to_json`            |                     |                     |                     |
-| `to_pandas`          |                     |                     |                     |
-| `to_string`          |                     |                     |                     |
-| `unique`             |         ✅          |          ✅         |         ✅          |
-| `value_counts`       |         ✅          |          ✅         |         ✅          |
-| `values_to_string`   |                     |                     |                     |
-| `where`              |                     |                     |                     |
-| `get_json_object`    |                     | ✅ (`getJSONObject`)|                     |
+| cuDF                 |      List Series      |     String Series     |     Struct Series     |
+| -------------------- | :-------------------: | :-------------------: | :-------------------: |
+| `add`                |                       |                       |                       |
+| `all`                |          ✅           |          ✅           |          ✅           |
+| `any`                |          ✅           |          ✅           |          ✅           |
+| `append`             |     ✅ (`concat`)     |     ✅ (`concat`)     |     ✅ (`concat`)     |
+| `applymap`           |                       |                       |                       |
+| `argsort`            |                       |                       |                       |
+| `as_index`           |                       |                       |                       |
+| `as_mask`            |                       |                       |                       |
+| `astype`             |      ✅ (`cast`)      |      ✅ (`cast`)      |      ✅ (`cast`)      |
+| `clip`               |                       |                       |                       |
+| `copy`               |                       |                       |                       |
+| `count`              | ✅ (`countNonNulls`)  | ✅ (`countNonNulls`)  | ✅ (`countNonNulls`)  |
+| `describe`           |                       |                       |                       |
+| `diff`               |                       |                       |                       |
+| `digitize`           |                       |                       |                       |
+| `drop_duplicates`    | ✅ (`dropDuplicates`) | ✅ (`dropDuplicates`) | ✅ (`dropDuplicates`) |
+| `dropna`             |   ✅ (`dropNulls`)    |   ✅ (`dropNulls`)    |   ✅ (`dropNulls`)    |
+| `equals`             |                       |                       |                       |
+| `factorize`          |                       |                       |                       |
+| `fillna`             |  ✅ (`replaceNulls`)  |  ✅ (`replaceNulls`)  |  ✅ (`replaceNulls`)  |
+| `from_arrow`         |                       |                       |                       |
+| `from_categorical`   |                       |                       |                       |
+| `from_masked_array`  |                       |                       |                       |
+| `from_pandas`        |                       |                       |                       |
+| `groupby`            |                       |                       |                       |
+| `hash_encode`        |                       |                       |                       |
+| `hash_values`        |                       |                       |                       |
+| `head`               |                       |                       |                       |
+| `interleave_columns` |                       |                       |                       |
+| `isin`               |                       |                       |                       |
+| `isna`               |     ✅ (`isNull`)     |     ✅ (`isNull`)     |     ✅ (`isNull`)     |
+| `isnull`             |          ✅           |          ✅           |          ✅           |
+| `keys`               |                       |                       |                       |
+| `kurt`               |                       |                       |                       |
+| `kurtosis`           |                       |                       |                       |
+| `label_encoding`     |                       |                       |                       |
+| `map`                |                       |                       |                       |
+| `mask`               |                       |                       |                       |
+| `memory_usage`       |                       |                       |                       |
+| `nans_to_nulls`      |  ✅ (`nansToNulls`)   |  ✅ (`nansToNulls`)   |  ✅ (`nansToNulls`)   |
+| `notna`              |   ✅ (`isNotNull`)    |   ✅ (`isNotNull`)    |   ✅ (`isNotNull`)    |
+| `notnull`            |   ✅ (`isNotNull`)    |   ✅ (`isNotNull`)    |   ✅ (`isNotNull`)    |
+| `nunique`            |                       |                       |                       |
+| `one_hot_encoding`   |                       |                       |                       |
+| `pipe`               |                       |                       |                       |
+| `quantile`           |                       |                       |                       |
+| `rank`               |                       |                       |                       |
+| `reindex`            |                       |                       |                       |
+| `rename`             |                       |                       |                       |
+| `repeat`             |                       |                       |                       |
+| `replace`            |                       |                       |                       |
+| `reset_index`        |                       |                       |                       |
+| `reverse`            |                       |                       |                       |
+| `rolling`            |                       |                       |                       |
+| `sample`             |                       |                       |                       |
+| `scatter_by_map`     |                       |                       |                       |
+| `searchsorted`       |                       |                       |                       |
+| `set_index`          |                       |                       |                       |
+| `set_mask`           |                       |                       |                       |
+| `shift`              |                       |                       |                       |
+| `skew`               |                       |                       |                       |
+| `sort_index`         |                       |                       |                       |
+| `sort_values`        |                       |                       |                       |
+| `tail`               |                       |                       |                       |
+| `take`               |     ✅ (`gather`)     |     ✅ (`gather`)     |     ✅ (`gather`)     |
+| `tile`               |                       |                       |                       |
+| `to_array`           |                       |                       |                       |
+| `to_arrow`           |                       |                       |                       |
+| `to_dlpack`          |                       |                       |                       |
+| `to_frame`           |                       |                       |                       |
+| `to_gpu_array`       |                       |                       |                       |
+| `to_hdf`             |                       |                       |                       |
+| `to_json`            |                       |                       |                       |
+| `to_pandas`          |                       |                       |                       |
+| `to_string`          |                       |                       |                       |
+| `unique`             |          ✅           |          ✅           |          ✅           |
+| `value_counts`       |          ✅           |          ✅           |          ✅           |
+| `values_to_string`   |                       |                       |                       |
+| `where`              |                       |                       |                       |
+| `get_json_object`    |                       | ✅ (`getJSONObject`)  |                       |
 
 ### DataFrame
 
-| cuDF                 |    node-rapids     |
-| -------------------- | :----------------: |
-| `acos`               |         ✅         |
-| `add`                |                    |
-| `agg`                |                    |
-| `all`                |                    |
-| `any`                |                    |
-| `append`             |                    |
-| `apply_chunks`       |                    |
-| `apply_rows`         |                    |
-| `argsort`            |                    |
-| `as_gpu_matrix`      |                    |
-| `as_matrix`          |                    |
-| `asin`               |         ✅         |
-| `assign`             |         ✅         |
-| `astype`             |    ✅ (`cast`)     |
-| `atan`               |         ✅         |
-| `clip`               |                    |
-| `copy`               |                    |
-| `corr`               |                    |
-| `cos`                |         ✅         |
-| `count`              |                    |
-| `cov`                |                    |
-| `cummax`             |                    |
-| `cummin`             |                    |
-| `cumprod`            |                    |
-| `cumsum`             |                    |
-| `describe`           |                    |
-| `div`                |                    |
-| `drop`               |         ✅         |
-| `drop_duplicates`    |                    |
-| `dropna`             |  ✅ (`dropNulls`)  |
-| `equals`             |                    |
-| `exp`                |         ✅         |
-| `fillna`             |                    |
-| `floordiv`           |                    |
-| `from_arrow`         |                    |
-| `from_pandas`        |                    |
-| `from_records`       |                    |
-| `hash_columns`       |                    |
-| `head`               |                    |
-| `info`               |                    |
-| `insert`             |                    |
-| `interleave_columns` |                    |
-| `isin`               |                    |
-| `isna`               |    ✅ (`isNaN`)    |
-| `isnull`             |         ✅         |
-| `iteritems`          |                    |
-| `join`               |                    |
-| `keys`               |                    |
-| `kurt`               |                    |
-| `kurtosis`           |                    |
-| `label_encoding`     |                    |
-| `log`                |         ✅         |
-| `mask`               |                    |
-| `max`                |                    |
-| `mean`               |                    |
-| `melt`               |                    |
-| `memory_usage`       |                    |
-| `merge`              |                    |
-| `min`                |                    |
-| `mod`                |                    |
-| `mode`               |                    |
-| `mul`                |                    |
-| `nans_to_nulls`      | ✅ (`nansToNulls`) |
-| `nlargest`           |                    |
-| `notna`              |  ✅ (`isNotNaN`)   |
-| `notnull`            |  ✅ (`isNotNull`)  |
-| `nsmallest`          |                    |
-| `one_hot_encoding`   |                    |
-| `partition_by_hash`  |                    |
-| `pipe`               |                    |
-| `pivot`              |                    |
-| `pop`                |                    |
-| `pow`                |                    |
-| `prod`               |                    |
-| `product`            |                    |
-| `quantile`           |                    |
-| `quantiles`          |                    |
-| `query`              |                    |
-| `radd`               |                    |
-| `rank`               |                    |
-| `rdiv`               |                    |
-| `reindex`            |                    |
-| `rename`             |                    |
-| `repeat`             |                    |
-| `replace`            |                    |
-| `reset_index`        |                    |
-| `rfloordiv`          |                    |
-| `rmod`               |                    |
-| `rmul`               |                    |
-| `round`              |                    |
-| `rpow`               |                    |
-| `rsub`               |                    |
-| `rtruediv`           |                    |
-| `sample`             |                    |
-| `scatter_by_map`     |                    |
-| `searchsorted`       |                    |
-| `select_dtypes`      |                    |
-| `set_index`          |                    |
-| `shift`              |                    |
-| `sin`                |         ✅         |
-| `skew`               |                    |
-| `sort_index`         |                    |
-| `sort_values`        | ✅ (`sortValues`)  |
-| `sqrt`               |         ✅         |
-| `stack`              |                    |
-| `std`                |                    |
-| `sub`                |                    |
-| `sum`                |                    |
-| `tail`               |                    |
-| `take`               |   ✅ (`gather`)    |
-| `tan`                |         ✅         |
-| `tile`               |                    |
-| `to_arrow`           |   ✅ (`toArrow`)   |
-| `to_csv`             |    ✅ (`toCSV`)    |
-| `to_dlpack`          |                    |
-| `to_feather`         |                    |
-| `to_hdf`             |                    |
-| `to_json`            |                    |
-| `to_orc`             |                    |
-| `to_pandas`          |                    |
-| `to_parquet`         |                    |
-| `to_records`         |                    |
-| `to_string`          |                    |
-| `transpose`          |                    |
-| `truediv`            |                    |
-| `unstack`            |                    |
-| `update`             |                    |
-| `var`                |                    |
-| `where`              |                    |
+| cuDF                 |      node-rapids      |
+| -------------------- | :-------------------: |
+| `acos`               |          ✅           |
+| `add`                |                       |
+| `agg`                |                       |
+| `all`                |                       |
+| `any`                |                       |
+| `append`             |                       |
+| `apply_chunks`       |                       |
+| `apply_rows`         |                       |
+| `argsort`            |                       |
+| `as_gpu_matrix`      |                       |
+| `as_matrix`          |                       |
+| `asin`               |          ✅           |
+| `assign`             |          ✅           |
+| `astype`             |      ✅ (`cast`)      |
+| `atan`               |          ✅           |
+| `clip`               |                       |
+| `copy`               |                       |
+| `corr`               |                       |
+| `cos`                |          ✅           |
+| `count`              |                       |
+| `cov`                |                       |
+| `cummax`             |                       |
+| `cummin`             |                       |
+| `cumprod`            |                       |
+| `cumsum`             |                       |
+| `describe`           |                       |
+| `div`                |                       |
+| `drop`               |          ✅           |
+| `drop_duplicates`    | ✅ (`dropDuplicates`) |
+| `dropna`             |   ✅ (`dropNulls`)    |
+| `equals`             |                       |
+| `exp`                |          ✅           |
+| `fillna`             |                       |
+| `floordiv`           |                       |
+| `from_arrow`         |                       |
+| `from_pandas`        |                       |
+| `from_records`       |                       |
+| `hash_columns`       |                       |
+| `head`               |                       |
+| `info`               |                       |
+| `insert`             |                       |
+| `interleave_columns` |                       |
+| `isin`               |                       |
+| `isna`               |     ✅ (`isNaN`)      |
+| `isnull`             |          ✅           |
+| `iteritems`          |                       |
+| `join`               |                       |
+| `keys`               |                       |
+| `kurt`               |                       |
+| `kurtosis`           |                       |
+| `label_encoding`     |                       |
+| `log`                |          ✅           |
+| `mask`               |                       |
+| `max`                |                       |
+| `mean`               |                       |
+| `melt`               |                       |
+| `memory_usage`       |                       |
+| `merge`              |                       |
+| `min`                |                       |
+| `mod`                |                       |
+| `mode`               |                       |
+| `mul`                |                       |
+| `nans_to_nulls`      |  ✅ (`nansToNulls`)   |
+| `nlargest`           |                       |
+| `notna`              |    ✅ (`isNotNaN`)    |
+| `notnull`            |   ✅ (`isNotNull`)    |
+| `nsmallest`          |                       |
+| `one_hot_encoding`   |                       |
+| `partition_by_hash`  |                       |
+| `pipe`               |                       |
+| `pivot`              |                       |
+| `pop`                |                       |
+| `pow`                |                       |
+| `prod`               |                       |
+| `product`            |                       |
+| `quantile`           |                       |
+| `quantiles`          |                       |
+| `query`              |                       |
+| `radd`               |                       |
+| `rank`               |                       |
+| `rdiv`               |                       |
+| `reindex`            |                       |
+| `rename`             |                       |
+| `repeat`             |                       |
+| `replace`            |                       |
+| `reset_index`        |                       |
+| `rfloordiv`          |                       |
+| `rmod`               |                       |
+| `rmul`               |                       |
+| `round`              |                       |
+| `rpow`               |                       |
+| `rsub`               |                       |
+| `rtruediv`           |                       |
+| `sample`             |                       |
+| `scatter_by_map`     |                       |
+| `searchsorted`       |                       |
+| `select_dtypes`      |                       |
+| `set_index`          |                       |
+| `shift`              |                       |
+| `sin`                |          ✅           |
+| `skew`               |                       |
+| `sort_index`         |                       |
+| `sort_values`        |   ✅ (`sortValues`)   |
+| `sqrt`               |          ✅           |
+| `stack`              |                       |
+| `std`                |                       |
+| `sub`                |                       |
+| `sum`                |                       |
+| `tail`               |                       |
+| `take`               |     ✅ (`gather`)     |
+| `tan`                |          ✅           |
+| `tile`               |                       |
+| `to_arrow`           |    ✅ (`toArrow`)     |
+| `to_csv`             |     ✅ (`toCSV`)      |
+| `to_dlpack`          |                       |
+| `to_feather`         |                       |
+| `to_hdf`             |                       |
+| `to_json`            |                       |
+| `to_orc`             |                       |
+| `to_pandas`          |                       |
+| `to_parquet`         |                       |
+| `to_records`         |                       |
+| `to_string`          |                       |
+| `transpose`          |                       |
+| `truediv`            |                       |
+| `unstack`            |                       |
+| `update`             |                       |
+| `var`                |                       |
+| `where`              |                       |
 
 ### GroupBy
 

--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -181,7 +181,6 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        // column/stream_compaction.cpp
                        InstanceMethod<&Column::drop_nulls>("drop_nulls"),
                        InstanceMethod<&Column::drop_nans>("drop_nans"),
-                       InstanceMethod<&Column::drop_duplicates>("drop_duplicates"),
                        // column/filling.cpp
                        StaticMethod<&Column::sequence>("sequence"),
                        // column/transform.cpp

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -1058,16 +1058,6 @@ export interface Column<T extends DataType = any> {
    */
   nans_to_nulls(memoryResource?: MemoryResource): Column<T>;
 
-  /**
-   * Drop duplicate values from the column
-   *
-   * @param nullsEqual Determines whether nulls are handled as equal values.
-   * @param memoryResource The optional MemoryResource used to allocate the result column's device
-   *   memory.
-   * @returns column without duplicate values
-   */
-  drop_duplicates(nullsEqual?: boolean, memoryResource?: MemoryResource): Column<T>;
-
   getJSONObject(jsonPath?: string, memoryResource?: MemoryResource): Column<T>;
 }
 

--- a/modules/cudf/src/column/stream_compaction.cpp
+++ b/modules/cudf/src/column/stream_compaction.cpp
@@ -64,26 +64,4 @@ Napi::Value Column::drop_nans(Napi::CallbackInfo const& info) {
   return drop_nans(NapiToCPP(info[0]).operator rmm::mr::device_memory_resource*());
 }
 
-Column::wrapper_t Column::drop_duplicates(bool is_nulls_equal,
-                                          rmm::mr::device_memory_resource* mr) const {
-  cudf::null_equality nulls_equal =
-    is_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
-
-  try {
-    return Column::New(Env(),
-                       std::move(cudf::drop_duplicates(cudf::table_view{{*this}},
-                                                       {0},
-                                                       cudf::duplicate_keep_option::KEEP_FIRST,
-                                                       nulls_equal,
-                                                       cudf::null_order::BEFORE,
-                                                       mr)
-                                   ->release()[0]));
-  } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(Env(), e.what())); }
-}
-
-Napi::Value Column::drop_duplicates(Napi::CallbackInfo const& info) {
-  CallbackArgs args{info};
-  return drop_duplicates(args[0], args[1]);
-}
-
 }  // namespace nv

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -357,16 +357,16 @@ export class DataFrame<T extends TypeMap = any> {
    * import {DataFrame, Series, Int32, NullOrder}  from '@rapidsai/cudf';
    * const df = new DataFrame({a: Series.new([null, 4, 3, 2, 1, 0])});
    *
-   * df.orderBy({a: {ascending: true, null_order: 'BEFORE'}});
+   * df.orderBy({a: {ascending: true, null_order: 'before'}});
    * // Int32Series [0, 5, 4, 3, 2, 1]
    *
-   * df.orderBy({a: {ascending: true, null_order: 'AFTER'}});
+   * df.orderBy({a: {ascending: true, null_order: 'after'}});
    * // Int32Series [5, 4, 3, 2, 1, 0]
    *
-   * df.orderBy({a: {ascending: false, null_order: 'BEFORE'}});
+   * df.orderBy({a: {ascending: false, null_order: 'before'}});
    * // Int32Series [1, 2, 3, 4, 5, 0]
    *
-   * df.orderBy({a: {ascending: false, null_order: 'AFTER'}});
+   * df.orderBy({a: {ascending: false, null_order: 'after'}});
    * // Int32Series [0, 1, 2, 3, 4, 5]
    * ```
    */
@@ -375,7 +375,7 @@ export class DataFrame<T extends TypeMap = any> {
     const null_orders   = new Array<NullOrder>();
     const columns       = new Array<Column<T[keyof T]>>();
     const entries       = Object.entries(options) as [R, OrderSpec][];
-    entries.forEach(([name, {ascending = true, null_order = 'AFTER'}]) => {
+    entries.forEach(([name, {ascending = true, null_order = 'after'}]) => {
       const child = this.get(name);
       if (child) {
         columns.push(child._col as Column<T[keyof T]>);
@@ -394,7 +394,7 @@ export class DataFrame<T extends TypeMap = any> {
    * @param ascending whether to sort ascending (true) or descending (false)
    *   Default: true
    * @param null_order whether nulls should sort before or after other values
-   *   Default: AFTER
+   *   Default: after
    *
    * @returns A new DataFrame of sorted values
    *
@@ -406,16 +406,16 @@ export class DataFrame<T extends TypeMap = any> {
    *   b: Series.new([0, 1, 2, 3, 4, 5])
    * });
    *
-   * df.sortValues({a: {ascending: true, null_order: 'AFTER'}})
+   * df.sortValues({a: {ascending: true, null_order: 'after'}})
    * // {a: [0, 1, 2, 3, 4, null], b: [5, 4, 3, 2, 1, 0]}
    *
-   * df.sortValues({a: {ascending: true, null_order: 'BEFORE'}})
+   * df.sortValues({a: {ascending: true, null_order: 'before'}})
    * // {a: [null, 0, 1, 2, 3, 4], b: [0, 5, 4, 3, 2, 1]}
    *
-   * df.sortValues({a: {ascending: false, null_order: 'AFTER'}})
+   * df.sortValues({a: {ascending: false, null_order: 'after'}})
    * // {a: [4, 3, 2, 1, 0, null], b: [1, 2, 3, 4, 5, 0]}
    *
-   * df.sortValues({a: {ascending: false, null_order: 'BEFORE'}})
+   * df.sortValues({a: {ascending: false, null_order: 'before'}})
    * // {a: [null, 4, 3, 2, 1, 0], b: [0, 1, 2, 3, 4, 5]}
    * ```
    */

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -634,12 +634,11 @@ export class DataFrame<T extends TypeMap = any> {
    * @ignore
    */
   _dropNullsRows(thresh = 1, subset = this.names) {
-    const column_names: (keyof T)[] = [];
-    const column_indices: number[]  = [];
-    subset.forEach((col, idx) => {
-      if (this.names.includes(col)) {
-        column_names.push(col);
-        column_indices.push(idx);
+    const column_indices: number[] = [];
+    const allNames                 = this.names;
+    subset.forEach((col) => {
+      if (allNames.includes(col)) {
+        column_indices.push(allNames.indexOf(col));
       } else {
         throw new Error(`Unknown column name: ${col.toString()}`);
       }
@@ -647,23 +646,22 @@ export class DataFrame<T extends TypeMap = any> {
 
     const table_result = new Table({columns: this._accessor.columns});
     const result       = table_result.drop_nulls(column_indices, thresh);
-    return new DataFrame(this.names.reduce(
-      (map, name, i) => ({...map, [name]: Series.new(result.getColumnByIndex(i))}),
-      {} as SeriesMap<T>));
+    return new DataFrame(
+      allNames.reduce((map, name, i) => ({...map, [name]: Series.new(result.getColumnByIndex(i))}),
+                      {} as SeriesMap<T>));
   }
   /**
    * drop rows with NaN values (float type only)
    * @ignore
    */
   _dropNaNsRows(thresh = 1, subset = this.names) {
-    const column_names: (keyof T)[] = [];
-    const column_indices: number[]  = [];
-    subset.forEach((col, idx) => {
-      if (this.names.includes(col) &&
+    const column_indices: number[] = [];
+    const allNames                 = this.names;
+    subset.forEach((col) => {
+      if (allNames.includes(col) &&
           [new Float32, new Float64].some((t) => this.get(col).type.compareTo(t))) {
-        column_names.push(col);
-        column_indices.push(idx);
-      } else if (!this.names.includes(col)) {
+        column_indices.push(allNames.indexOf(col));
+      } else if (!allNames.includes(col)) {
         throw new Error(`Unknown column name: ${col.toString()}`);
       } else {
         // col exists but not of floating type
@@ -672,9 +670,9 @@ export class DataFrame<T extends TypeMap = any> {
     });
     const table_result = new Table({columns: this._accessor.columns});
     const result       = table_result.drop_nans(column_indices, thresh);
-    return new DataFrame(this.names.reduce(
-      (map, name, i) => ({...map, [name]: Series.new(result.getColumnByIndex(i))}),
-      {} as SeriesMap<T>));
+    return new DataFrame(
+      allNames.reduce((map, name, i) => ({...map, [name]: Series.new(result.getColumnByIndex(i))}),
+                      {} as SeriesMap<T>));
   }
   /**
    * drop columns with nulls

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -583,10 +583,6 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Column::wrapper_t drop_nans(
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
-  Column::wrapper_t drop_duplicates(
-    bool nulls_equal,
-    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
-
   // column/filling.cpp
   static Column::wrapper_t sequence(
     Napi::Env const& env,
@@ -755,7 +751,6 @@ struct Column : public EnvLocalObjectWrap<Column> {
   // column/stream_compaction.cpp
   Napi::Value drop_nulls(Napi::CallbackInfo const& info);
   Napi::Value drop_nans(Napi::CallbackInfo const& info);
-  Napi::Value drop_duplicates(Napi::CallbackInfo const& info);
 
   // column/filling.cpp
   static Napi::Value sequence(Napi::CallbackInfo const& info);

--- a/modules/cudf/src/node_cudf/table.hpp
+++ b/modules/cudf/src/node_cudf/table.hpp
@@ -122,6 +122,7 @@ struct Table : public EnvLocalObjectWrap<Table> {
     return *Column::Unwrap(columns_.Value().Get(i).ToObject());
   }
 
+  // table/stream_compaction.cpp
   Table::wrapper_t apply_boolean_mask(
     Column const& boolean_mask,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
@@ -134,6 +135,12 @@ struct Table : public EnvLocalObjectWrap<Table> {
   Table::wrapper_t drop_nans(
     std::vector<cudf::size_type> keys,
     cudf::size_type threshold,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  Table::wrapper_t drop_duplicates(
+    cudf::duplicate_keep_option keep,
+    bool nulls_equal,
+    bool is_nulls_first,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
   // table/copying.cpp
@@ -202,8 +209,10 @@ struct Table : public EnvLocalObjectWrap<Table> {
   Napi::Value num_rows(Napi::CallbackInfo const& info);
   Napi::Value select(Napi::CallbackInfo const& info);
   Napi::Value get_column(Napi::CallbackInfo const& info);
+  // table/stream_compaction.cpp
   Napi::Value drop_nulls(Napi::CallbackInfo const& info);
   Napi::Value drop_nans(Napi::CallbackInfo const& info);
+  Napi::Value drop_duplicates(Napi::CallbackInfo const& info);
   // table/copying.cpp
   Napi::Value gather(Napi::CallbackInfo const& info);
   Napi::Value scatter_scalar(Napi::CallbackInfo const& info);

--- a/modules/cudf/src/node_cudf/table.hpp
+++ b/modules/cudf/src/node_cudf/table.hpp
@@ -138,6 +138,7 @@ struct Table : public EnvLocalObjectWrap<Table> {
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
   Table::wrapper_t drop_duplicates(
+    std::vector<cudf::size_type> keys,
     cudf::duplicate_keep_option keep,
     bool nulls_equal,
     bool is_nulls_first,

--- a/modules/cudf/src/node_cudf/utilities/napi_to_cpp.hpp
+++ b/modules/cudf/src/node_cudf/utilities/napi_to_cpp.hpp
@@ -19,6 +19,7 @@
 
 #include <nv_node/utilities/napi_to_cpp.hpp>
 
+#include <cudf/stream_compaction.hpp>
 #include <cudf/types.hpp>
 
 #include <napi.h>
@@ -115,6 +116,11 @@ inline NapiToCPP::operator cudf::timestamp_ns() const {
 template <>
 inline NapiToCPP::operator cudf::interpolation() const {
   return static_cast<cudf::interpolation>(operator int32_t());
+}
+
+template <>
+inline NapiToCPP::operator cudf::duplicate_keep_option() const {
+  return static_cast<cudf::duplicate_keep_option>(operator int32_t());
 }
 
 }  // namespace nv

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -939,9 +939,10 @@ export class AbstractSeries<T extends DataType = any> {
                  nullsEqual: boolean,
                  nullsFirst: boolean,
                  memoryResource?: MemoryResource) {
-    return Series.new(new Table({columns: [this._col]})
-                        .dropDuplicates([0], keep, nullsEqual, nullsFirst, memoryResource)
-                        .getColumnByIndex(0));
+    return Series.new(
+      new Table({columns: [this._col]})
+        .dropDuplicates([0], DuplicateKeepOption[keep], nullsEqual, nullsFirst, memoryResource)
+        .getColumnByIndex(0));
   }
 }
 

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -916,6 +916,27 @@ export class AbstractSeries<T extends DataType = any> {
   unique(nullsEqual = true, memoryResource?: MemoryResource) {
     return this.__construct(this._col.drop_duplicates(nullsEqual, memoryResource));
   }
+
+  /**
+   * Returns a new Series with duplicate values from the original removed
+   *
+   * @param keys The indices of columns that should be considered when searching for duplicate
+   *   values
+   * @param keep Determines whether to keep the first, last, or none of the duplicate items.
+   * @param nullsEqual Determines whether nulls are handled as equal values.
+   * @param nullsFirst Determines whether null values are inserted before or after non-null values
+   * @param memoryResource Memory resource used to allocate the result Column's device memory.
+   * @returns series without duplicate values
+   */
+  dropDuplicates(keys: number[],
+                 keep: keyof typeof DuplicateKeepOption,
+                 nullsEqual: boolean,
+                 nullsFirst: boolean,
+                 memoryResource?: MemoryResource) {
+    return Series.new(new Table({columns: [this._col]})
+                        .dropDuplicates(keys, keep, nullsEqual, nullsFirst, memoryResource)
+                        .getColumnByIndex(0));
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -931,7 +931,7 @@ export class AbstractSeries<T extends DataType = any> {
    *
    * @param keep Determines whether or not to keep the duplicate items.
    * @param nullsEqual Determines whether nulls are handled as equal values.
-   * @param nullsFirst Determines whether null values are inserted before or after non-null values
+   * @param nullsFirst Determines whether null values are inserted before or after non-null values.
    * @param memoryResource Memory resource used to allocate the result Column's device memory.
    * @returns series without duplicate values
    *

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -907,14 +907,23 @@ export class AbstractSeries<T extends DataType = any> {
   }
 
   /**
-   * Removes duplicate values from the Series.
+   * Returns a new Series with only the unique values that were found in the original
    *
    * @param nullsEqual Determines whether nulls are handled as equal values.
    * @param memoryResource Memory resource used to allocate the result Column's device memory.
    * @returns series without duplicate values
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // Float64Series
+   * Series.new([null, null, 1, 2, 3, 3]).unique(true) // [null, 1, 2, 3]
+   * Series.new([null, null, 1, 2, 3, 3]).unique(false) // [null, null, 1, 2, 3]
+   * ```
    */
   unique(nullsEqual = true, memoryResource?: MemoryResource) {
-    return this.__construct(this._col.drop_duplicates(nullsEqual, memoryResource));
+    return this.dropDuplicates([0], 'keep_first', nullsEqual, true, memoryResource);
   }
 
   /**

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -923,25 +923,44 @@ export class AbstractSeries<T extends DataType = any> {
    * ```
    */
   unique(nullsEqual = true, memoryResource?: MemoryResource) {
-    return this.dropDuplicates('keep_first', nullsEqual, true, memoryResource);
+    return this.dropDuplicates(true, nullsEqual, true, memoryResource);
   }
 
   /**
    * Returns a new Series with duplicate values from the original removed
    *
-   * @param keep Determines whether to keep the first, last, or none of the duplicate items.
+   * @param keep Determines whether or not to keep the duplicate items.
    * @param nullsEqual Determines whether nulls are handled as equal values.
    * @param nullsFirst Determines whether null values are inserted before or after non-null values
    * @param memoryResource Memory resource used to allocate the result Column's device memory.
    * @returns series without duplicate values
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // Float64Series
+   * Series.new([4, null, 1, 2, null, 3, 4]).dropDuplicates(
+   *   true,
+   *   true,
+   *   true
+   * ) // [null, 1, 2, 3, 4]
+   *
+   * Series.new([4, null, 1, 2, null, 3, 4]).dropDuplicates(
+   *   false,
+   *   true,
+   *   true
+   * ) // [1, 2, 3]
+   * ```
    */
-  dropDuplicates(keep: keyof typeof DuplicateKeepOption,
+  dropDuplicates(keep: boolean,
                  nullsEqual: boolean,
                  nullsFirst: boolean,
                  memoryResource?: MemoryResource) {
     return Series.new(
       new Table({columns: [this._col]})
-        .dropDuplicates([0], DuplicateKeepOption[keep], nullsEqual, nullsFirst, memoryResource)
+        .dropDuplicates(
+          [0], DuplicateKeepOption[keep ? 'first' : 'none'], nullsEqual, nullsFirst, memoryResource)
         .getColumnByIndex(0));
   }
 }

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -817,11 +817,11 @@ export class AbstractSeries<T extends DataType = any> {
    * Series.new([true, false, true, true, false]).orderBy(false) // [0, 2, 3, 1, 4]
    *
    * // NullOrder usage
-   * Series.new([50, 40, 30, 20, 10, null]).orderBy(false, 'BEFORE') // [0, 1, 2, 3, 4, 5]
-   * Series.new([50, 40, 30, 20, 10, null]).orderBy(false, 'AFTER') // [5, 0, 1, 2, 3, 4]
+   * Series.new([50, 40, 30, 20, 10, null]).orderBy(false, 'before') // [0, 1, 2, 3, 4, 5]
+   * Series.new([50, 40, 30, 20, 10, null]).orderBy(false, 'after') // [5, 0, 1, 2, 3, 4]
    * ```
    */
-  orderBy(ascending = true, null_order: keyof typeof NullOrder = 'AFTER') {
+  orderBy(ascending = true, null_order: keyof typeof NullOrder = 'after') {
     return Series.new(
       new Table({columns: [this._col]}).orderBy([ascending], [NullOrder[null_order]]));
   }
@@ -832,7 +832,7 @@ export class AbstractSeries<T extends DataType = any> {
    * @param ascending whether to sort ascending (true) or descending (false)
    *   Default: true
    * @param null_order whether nulls should sort before or after other values
-   *   Default: BEFORE
+   *   Default: before
    *
    * @returns Sorted values
    *
@@ -855,14 +855,14 @@ export class AbstractSeries<T extends DataType = any> {
    * false, false]
    *
    * // NullOrder usage
-   * Series.new([50, 40, 30, 20, 10, null]).sortValues(false, 'BEFORE') // [50, 40, 30, 20,
+   * Series.new([50, 40, 30, 20, 10, null]).sortValues(false, 'before') // [50, 40, 30, 20,
    * 10, null]
    *
-   * Series.new([50, 40, 30, 20, 10, null]).sortValues(false, 'AFTER') // [null, 50, 40, 30,
+   * Series.new([50, 40, 30, 20, 10, null]).sortValues(false, 'after') // [null, 50, 40, 30,
    * 20, 10]
    * ```
    */
-  sortValues(ascending = true, null_order: keyof typeof NullOrder = 'AFTER'): Series<T> {
+  sortValues(ascending = true, null_order: keyof typeof NullOrder = 'after'): Series<T> {
     return this.gather(this.orderBy(ascending, null_order));
   }
 

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -923,27 +923,24 @@ export class AbstractSeries<T extends DataType = any> {
    * ```
    */
   unique(nullsEqual = true, memoryResource?: MemoryResource) {
-    return this.dropDuplicates([0], 'keep_first', nullsEqual, true, memoryResource);
+    return this.dropDuplicates('keep_first', nullsEqual, true, memoryResource);
   }
 
   /**
    * Returns a new Series with duplicate values from the original removed
    *
-   * @param keys The indices of columns that should be considered when searching for duplicate
-   *   values
    * @param keep Determines whether to keep the first, last, or none of the duplicate items.
    * @param nullsEqual Determines whether nulls are handled as equal values.
    * @param nullsFirst Determines whether null values are inserted before or after non-null values
    * @param memoryResource Memory resource used to allocate the result Column's device memory.
    * @returns series without duplicate values
    */
-  dropDuplicates(keys: number[],
-                 keep: keyof typeof DuplicateKeepOption,
+  dropDuplicates(keep: keyof typeof DuplicateKeepOption,
                  nullsEqual: boolean,
                  nullsFirst: boolean,
                  memoryResource?: MemoryResource) {
     return Series.new(new Table({columns: [this._col]})
-                        .dropDuplicates(keys, keep, nullsEqual, nullsFirst, memoryResource)
+                        .dropDuplicates([0], keep, nullsEqual, nullsFirst, memoryResource)
                         .getColumnByIndex(0));
   }
 }

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -47,6 +47,7 @@ import {
   Utf8String,
 } from './types/dtypes';
 import {
+  DuplicateKeepOption,
   NullOrder,
 } from './types/enums';
 import {ArrowToCUDFType, arrowToCUDFType} from './types/mappings';

--- a/modules/cudf/src/table.cpp
+++ b/modules/cudf/src/table.cpp
@@ -45,7 +45,7 @@ Napi::Function Table::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Table::write_csv>("writeCSV"),
                        InstanceMethod<&Table::drop_nans>("drop_nans"),
                        InstanceMethod<&Table::drop_nulls>("drop_nulls"),
-                       InstanceMethod<&Table::drop_duplicates>("drop_duplicates"),
+                       InstanceMethod<&Table::drop_duplicates>("dropDuplicates"),
                        StaticMethod<&Table::full_join>("fullJoin"),
                        StaticMethod<&Table::inner_join>("innerJoin"),
                        StaticMethod<&Table::left_join>("leftJoin"),

--- a/modules/cudf/src/table.cpp
+++ b/modules/cudf/src/table.cpp
@@ -45,6 +45,7 @@ Napi::Function Table::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Table::write_csv>("writeCSV"),
                        InstanceMethod<&Table::drop_nans>("drop_nans"),
                        InstanceMethod<&Table::drop_nulls>("drop_nulls"),
+                       InstanceMethod<&Table::drop_duplicates>("drop_duplicates"),
                        StaticMethod<&Table::full_join>("fullJoin"),
                        StaticMethod<&Table::inner_join>("innerJoin"),
                        StaticMethod<&Table::left_join>("leftJoin"),

--- a/modules/cudf/src/table.ts
+++ b/modules/cudf/src/table.ts
@@ -185,7 +185,7 @@ export interface Table {
   drop_nans(keys: number[], threshold: number): Table;
   drop_nulls(keys: number[], threshold: number): Table;
   dropDuplicates(keys: number[],
-                 keep: keyof typeof DuplicateKeepOption,
+                 keep: DuplicateKeepOption,
                  nullsEqual: boolean,
                  nullsFirst: boolean,
                  memoryResource?: MemoryResource): Table;

--- a/modules/cudf/src/table.ts
+++ b/modules/cudf/src/table.ts
@@ -184,8 +184,11 @@ export interface Table {
 
   drop_nans(keys: number[], threshold: number): Table;
   drop_nulls(keys: number[], threshold: number): Table;
-  drop_duplicates(keep: keyof typeof DuplicateKeepOption, nullsEqual: boolean, nullsFirst: boolean):
-    Table;
+  dropDuplicates(keys: number[],
+                 keep: keyof typeof DuplicateKeepOption,
+                 nullsEqual: boolean,
+                 nullsFirst: boolean,
+                 memoryResource?: MemoryResource): Table;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/cudf/src/table.ts
+++ b/modules/cudf/src/table.ts
@@ -19,7 +19,7 @@ import {Scalar} from './scalar';
 import {CSVTypeMap, ReadCSVOptions, WriteCSVOptions} from './types/csv';
 import {Bool8, DataType, IndexType, Int32} from './types/dtypes';
 import {NullOrder} from './types/enums';
-import {TypeMap} from './types/mappings';
+import {DuplicateKeepOption, TypeMap} from './types/mappings';
 
 export type ToArrowMetadata = [string | number, ToArrowMetadata[]?];
 
@@ -184,6 +184,8 @@ export interface Table {
 
   drop_nans(keys: number[], threshold: number): Table;
   drop_nulls(keys: number[], threshold: number): Table;
+  drop_duplicates(keep: keyof typeof DuplicateKeepOption, nullsEqual: boolean, nullsFirst: boolean):
+    Table;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/cudf/src/table.ts
+++ b/modules/cudf/src/table.ts
@@ -18,8 +18,8 @@ import {Column} from './column';
 import {Scalar} from './scalar';
 import {CSVTypeMap, ReadCSVOptions, WriteCSVOptions} from './types/csv';
 import {Bool8, DataType, IndexType, Int32} from './types/dtypes';
-import {NullOrder} from './types/enums';
-import {DuplicateKeepOption, TypeMap} from './types/mappings';
+import {DuplicateKeepOption, NullOrder} from './types/enums';
+import {TypeMap} from './types/mappings';
 
 export type ToArrowMetadata = [string | number, ToArrowMetadata[]?];
 

--- a/modules/cudf/src/table/stream_compaction.cpp
+++ b/modules/cudf/src/table/stream_compaction.cpp
@@ -61,7 +61,8 @@ Napi::Value Table::drop_nans(Napi::CallbackInfo const& info) {
   return drop_nans(args[0], args[1], args[2]);
 }
 
-Table::wrapper_t Table::drop_duplicates(cudf::duplicate_keep_option keep,
+Table::wrapper_t Table::drop_duplicates(std::vector<cudf::size_type> keys,
+                                        cudf::duplicate_keep_option keep,
                                         bool is_nulls_equal,
                                         bool is_nulls_first,
                                         rmm::mr::device_memory_resource* mr) const {
@@ -77,7 +78,7 @@ Table::wrapper_t Table::drop_duplicates(cudf::duplicate_keep_option keep,
 
 Napi::Value Table::drop_duplicates(Napi::CallbackInfo const& info) {
   CallbackArgs args{info};
-  return drop_duplicates(args[0], args[1], args[2], args[3]);
+  return drop_duplicates(args[0], args[1], args[2], args[3], args[4]);
 }
 
 }  // namespace nv

--- a/modules/cudf/src/table/stream_compaction.cpp
+++ b/modules/cudf/src/table/stream_compaction.cpp
@@ -55,4 +55,23 @@ Napi::Value Table::drop_nans(Napi::CallbackInfo const& info) {
   return drop_nans(args[0], args[1], args[2]);
 }
 
+Table::wrapper_t Table::drop_duplicates(cudf::duplicate_keep_option keep,
+                                        bool is_nulls_equal,
+                                        bool is_nulls_first,
+                                        rmm::mr::device_memory_resource* mr) const {
+  cudf::null_equality nulls_equal =
+    is_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
+  cudf::null_order nulls_first =
+    is_nulls_first ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
+
+  try {
+    return Table::New(Env(), cudf::drop_duplicates(*this, {0}, keep, nulls_equal, nulls_first, mr));
+  } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(Env(), e.what())); }
+}
+
+Napi::Value Table::drop_duplicates(Napi::CallbackInfo const& info) {
+  CallbackArgs args{info};
+  return drop_duplicates(args[0], args[1], args[2], args[3]);
+}
+
 }  // namespace nv

--- a/modules/cudf/src/table/stream_compaction.cpp
+++ b/modules/cudf/src/table/stream_compaction.cpp
@@ -72,7 +72,8 @@ Table::wrapper_t Table::drop_duplicates(std::vector<cudf::size_type> keys,
     is_nulls_first ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
 
   try {
-    return Table::New(Env(), cudf::drop_duplicates(*this, {0}, keep, nulls_equal, nulls_first, mr));
+    return Table::New(Env(),
+                      cudf::drop_duplicates(*this, keys, keep, nulls_equal, nulls_first, mr));
   } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(Env(), e.what())); }
 }
 

--- a/modules/cudf/src/table/stream_compaction.cpp
+++ b/modules/cudf/src/table/stream_compaction.cpp
@@ -30,13 +30,17 @@ namespace nv {
 
 Table::wrapper_t Table::apply_boolean_mask(Column const& boolean_mask,
                                            rmm::mr::device_memory_resource* mr) const {
-  return Table::New(Env(), cudf::apply_boolean_mask(cudf::table_view{{*this}}, boolean_mask, mr));
+  try {
+    return Table::New(Env(), cudf::apply_boolean_mask(cudf::table_view{{*this}}, boolean_mask, mr));
+  } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(Env(), e.what())); }
 }
 
 Table::wrapper_t Table::drop_nulls(std::vector<cudf::size_type> keys,
                                    cudf::size_type threshold,
                                    rmm::mr::device_memory_resource* mr) const {
-  return Table::New(Env(), cudf::drop_nulls(*this, keys, threshold, mr));
+  try {
+    return Table::New(Env(), cudf::drop_nulls(*this, keys, threshold, mr));
+  } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(Env(), e.what())); }
 }
 
 Napi::Value Table::drop_nulls(Napi::CallbackInfo const& info) {
@@ -47,7 +51,9 @@ Napi::Value Table::drop_nulls(Napi::CallbackInfo const& info) {
 Table::wrapper_t Table::drop_nans(std::vector<cudf::size_type> keys,
                                   cudf::size_type threshold,
                                   rmm::mr::device_memory_resource* mr) const {
-  return Table::New(Env(), cudf::drop_nans(*this, keys, threshold, mr));
+  try {
+    return Table::New(Env(), cudf::drop_nans(*this, keys, threshold, mr));
+  } catch (cudf::logic_error const& e) { NAPI_THROW(Napi::Error::New(Env(), e.what())); }
 }
 
 Napi::Value Table::drop_nans(Napi::CallbackInfo const& info) {

--- a/modules/cudf/src/types/enums.ts
+++ b/modules/cudf/src/types/enums.ts
@@ -23,7 +23,7 @@ export enum NullOrder
 
 export enum DuplicateKeepOption
 {
-  keep_first,  // Keeps first duplicate row and unique rows.
-  keep_last,   // Keeps last duplicate row and unique rows.
-  keep_none,   // Keeps only unique rows are kept.
+  first,  // Keeps first duplicate row and unique rows.
+  last,   // Keeps last duplicate row and unique rows.
+  none,   // Keeps only unique rows are kept.
 }

--- a/modules/cudf/src/types/enums.ts
+++ b/modules/cudf/src/types/enums.ts
@@ -20,3 +20,10 @@ export enum NullOrder
   AFTER,
   BEFORE
 }
+
+export enum DuplicateKeepOption
+{
+  keep_first,  // Keeps first duplicate row and unique rows.
+  keep_last,   // Keeps last duplicate row and unique rows.
+  keep_none,   // Keeps only unique rows are kept.
+}

--- a/modules/cudf/src/types/enums.ts
+++ b/modules/cudf/src/types/enums.ts
@@ -17,8 +17,8 @@
  */
 export enum NullOrder
 {
-  AFTER,
-  BEFORE
+  after,
+  before
 }
 
 export enum DuplicateKeepOption

--- a/modules/cudf/src/types/mappings.ts
+++ b/modules/cudf/src/types/mappings.ts
@@ -50,6 +50,13 @@ export enum Interpolation
   nearest    ///< i or j, whichever is nearest
 }
 
+export enum DuplicateKeepOption
+{
+  keep_first,  // Keeps first duplicate row and unique rows.
+  keep_last,   // Keeps last duplicate row and unique rows.
+  keep_none,   // Keeps only unique rows are kept.
+}
+
 export type TypeMap = {
   [key: string]: DataType
 };

--- a/modules/cudf/src/types/mappings.ts
+++ b/modules/cudf/src/types/mappings.ts
@@ -50,13 +50,6 @@ export enum Interpolation
   nearest    ///< i or j, whichever is nearest
 }
 
-export enum DuplicateKeepOption
-{
-  keep_first,  // Keeps first duplicate row and unique rows.
-  keep_last,   // Keeps last duplicate row and unique rows.
-  keep_none,   // Keeps only unique rows are kept.
-}
-
 export type TypeMap = {
   [key: string]: DataType
 };

--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -152,7 +152,7 @@ test('DataFrame.drop', () => {
 test('DataFrame.orderBy (ascending, non-null)', () => {
   const col    = Series.new({type: new Int32(), data: new Int32Buffer([1, 3, 5, 4, 2, 0])});
   const df     = new DataFrame({'a': col});
-  const result = df.orderBy({'a': {ascending: true, null_order: 'BEFORE'}});
+  const result = df.orderBy({'a': {ascending: true, null_order: 'before'}});
 
   const expected = [5, 0, 4, 1, 3, 2];
   expect([...result]).toEqual([...Buffer.from(expected)]);
@@ -161,7 +161,7 @@ test('DataFrame.orderBy (ascending, non-null)', () => {
 test('DataFrame.orderBy (descending, non-null)', () => {
   const col    = Series.new({type: new Int32(), data: new Int32Buffer([1, 3, 5, 4, 2, 0])});
   const df     = new DataFrame({'a': col});
-  const result = df.orderBy({'a': {ascending: false, null_order: 'BEFORE'}});
+  const result = df.orderBy({'a': {ascending: false, null_order: 'before'}});
 
   const expected = [2, 3, 1, 4, 0, 5];
   expect([...result]).toEqual([...Buffer.from(expected)]);
@@ -172,7 +172,7 @@ test('DataFrame.orderBy (ascending, null before)', () => {
   const col =
     Series.new({type: new Int32(), data: new Int32Buffer([1, 3, 5, 4, 2, 0]), nullMask: mask});
   const df     = new DataFrame({'a': col});
-  const result = df.orderBy({'a': {ascending: true, null_order: 'BEFORE'}});
+  const result = df.orderBy({'a': {ascending: true, null_order: 'before'}});
 
   const expected = [1, 5, 0, 4, 3, 2];
   expect([...result]).toEqual([...Buffer.from(expected)]);
@@ -183,7 +183,7 @@ test('DataFrame.orderBy (ascending, null after)', () => {
   const col =
     Series.new({type: new Int32(), data: new Int32Buffer([1, 3, 5, 4, 2, 0]), nullMask: mask});
   const df     = new DataFrame({'a': col});
-  const result = df.orderBy({'a': {ascending: true, null_order: 'AFTER'}});
+  const result = df.orderBy({'a': {ascending: true, null_order: 'after'}});
 
   const expected = [5, 0, 4, 3, 2, 1];
   expect([...result]).toEqual([...Buffer.from(expected)]);
@@ -194,7 +194,7 @@ test('DataFrame.orderBy (descendng, null before)', () => {
   const col =
     Series.new({type: new Int32(), data: new Int32Buffer([1, 3, 5, 4, 2, 0]), nullMask: mask});
   const df     = new DataFrame({'a': col});
-  const result = df.orderBy({'a': {ascending: false, null_order: 'BEFORE'}});
+  const result = df.orderBy({'a': {ascending: false, null_order: 'before'}});
 
   const expected = [2, 3, 4, 0, 5, 1];
 
@@ -206,7 +206,7 @@ test('DataFrame.orderBy (descending, null after)', () => {
   const col =
     Series.new({type: new Int32(), data: new Int32Buffer([1, 3, 5, 4, 2, 0]), nullMask: mask});
   const df     = new DataFrame({'a': col});
-  const result = df.orderBy({'a': {ascending: false, null_order: 'AFTER'}});
+  const result = df.orderBy({'a': {ascending: false, null_order: 'after'}});
 
   const expected = [1, 2, 3, 4, 0, 5];
   expect([...result]).toEqual([...Buffer.from(expected)]);

--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -670,3 +670,35 @@ test('dataframe.isNotNull', () => {
   expect([...result.get('b')]).toEqual([...expected_b]);
   expect([...result.get('c')]).toEqual([...expected_c]);
 });
+
+test.each`
+keep       | nullsEqual | nullsFirst | data                                                    | expected
+${'first'} | ${true}    | ${true}    | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[null, 1, 3, 4], [null, 5, 8, 4]]}
+${'last'}  | ${true}    | ${true}    | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[null, 1, 3, 4], [null, 5, 8, 4]]}
+${'none'}  | ${true}    | ${true}    | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[1, 3], [5, 8]]}
+${'first'} | ${false}   | ${true}    | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[null, null, 1, 3, 4], [null, null, 5, 8, 4]]}
+${'last'}  | ${false}   | ${true}    | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[null, null, 1, 3, 4], [null, null, 5, 8, 4]]}
+${'none'}  | ${false}   | ${true}    | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[null, null, 1, 3], [null, null, 5, 8]]}
+${'first'} | ${true}    | ${false}   | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[1, 3, 4, null], [5, 8, 4, null]]}
+${'last'}  | ${true}    | ${false}   | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[1, 3, 4, null], [5, 8, 4, null]]}
+${'none'}  | ${true}    | ${false}   | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[1, 3], [5, 8]]}
+${'first'} | ${false}   | ${false}   | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[1, 3, 4, null, null], [5, 8, 4, null, null]]}
+${'last'}  | ${false}   | ${false}   | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[1, 3, 4, null, null], [5, 8, 4, null, null]]}
+${'none'}  | ${false}   | ${false}   | ${[[4, null, 1, null, 3, 4], [4, null, 5, null, 8, 4]]} | ${[[1, 3, null, null], [5, 8, null, null]]}
+`('DataFrame.dropDuplicates($keep, $nullsEqual, $nullsFirst)', ({keep, nullsEqual, nullsFirst, data, expected}) => {
+  const a      = Series.new(data[0]);
+  const b      = Series.new(data[1]);
+  const df = new DataFrame({a, b});
+  const result = df.dropDuplicates(keep, nullsEqual, nullsFirst);
+  expect([...result.get('a')]).toEqual(expected[0]);
+  expect([...result.get('b')]).toEqual(expected[1]);
+});
+
+test(`DataFrame.dropDuplicates("first", true, true, ['a'])`, () => {
+  const a      = Series.new([4, null, 1, null, 3, 4]);
+  const b      = Series.new([2, null, 5, null, 8, 9]);
+  const df     = new DataFrame({a, b});
+  const result = df.dropDuplicates('first', true, true, ['a']);
+  expect([...result.get('a')]).toEqual([null, 1, 3, 4]);
+  expect([...result.get('b')]).toEqual([null, 5, 8, 2]);
+});

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -283,7 +283,7 @@ describe('toArrow()', () => {
 
 test('Series.orderBy (ascending, non-null)', () => {
   const col    = Series.new({type: new Int32, data: new Int32Buffer([1, 3, 5, 4, 2, 0])});
-  const result = col.orderBy(true, 'BEFORE');
+  const result = col.orderBy(true, 'before');
 
   const expected = [5, 0, 4, 1, 3, 2];
   expect([...result]).toEqual(expected);
@@ -291,7 +291,7 @@ test('Series.orderBy (ascending, non-null)', () => {
 
 test('Series.orderBy (descending, non-null)', () => {
   const col    = Series.new({type: new Int32, data: new Int32Buffer([1, 3, 5, 4, 2, 0])});
-  const result = col.orderBy(false, 'BEFORE');
+  const result = col.orderBy(false, 'before');
 
   const expected = [2, 3, 1, 4, 0, 5];
   expect([...result]).toEqual(expected);
@@ -301,7 +301,7 @@ test('Series.orderBy (ascending, null before)', () => {
   const mask = new Uint8Buffer(BoolVector.from([1, 0, 1, 1, 1, 1]).values);
   const col =
     Series.new({type: new Int32, data: new Int32Buffer([1, 3, 5, 4, 2, 0]), nullMask: mask});
-  const result = col.orderBy(true, 'BEFORE');
+  const result = col.orderBy(true, 'before');
 
   const expected = [1, 5, 0, 4, 3, 2];
   expect([...result]).toEqual(expected);
@@ -311,7 +311,7 @@ test('Series.orderBy (ascending, null after)', () => {
   const mask = new Uint8Buffer(BoolVector.from([1, 0, 1, 1, 1, 1]).values);
   const col =
     Series.new({type: new Int32, data: new Int32Buffer([1, 3, 5, 4, 2, 0]), nullMask: mask});
-  const result = col.orderBy(true, 'AFTER');
+  const result = col.orderBy(true, 'after');
 
   const expected = [5, 0, 4, 3, 2, 1];
   expect([...result]).toEqual(expected);
@@ -321,7 +321,7 @@ test('Series.orderBy (descendng, null before)', () => {
   const mask = new Uint8Buffer(BoolVector.from([1, 0, 1, 1, 1, 1]).values);
   const col =
     Series.new({type: new Int32, data: new Int32Buffer([1, 3, 5, 4, 2, 0]), nullMask: mask});
-  const result = col.orderBy(false, 'BEFORE');
+  const result = col.orderBy(false, 'before');
 
   const expected = [2, 3, 4, 0, 5, 1];
 
@@ -332,7 +332,7 @@ test('Series.orderBy (descending, null after)', () => {
   const mask = new Uint8Buffer(BoolVector.from([1, 0, 1, 1, 1, 1]).values);
   const col =
     Series.new({type: new Int32, data: new Int32Buffer([1, 3, 5, 4, 2, 0]), nullMask: mask});
-  const result = col.orderBy(false, 'AFTER');
+  const result = col.orderBy(false, 'after');
 
   const expected = [1, 2, 3, 4, 0, 5];
   expect([...result]).toEqual(expected);

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -637,3 +637,19 @@ test('Series initialization with Date', () => {
   expect(val?.getUTCSeconds()).toBe(30);
   expect(val?.getUTCMilliseconds()).toBe(100);
 });
+
+test.each`
+keep     | nullsEqual | nullsFirst | data                           | expected
+${true}  | ${true}    | ${true}    | ${[4, null, 1, 2, null, 3, 4]} | ${[null, 1, 2, 3, 4]}
+${false} | ${true}    | ${true}    | ${[4, null, 1, 2, null, 3, 4]} | ${[1, 2, 3]}
+${true}  | ${true}    | ${false}   | ${[4, null, 1, 2, null, 3, 4]} | ${[1, 2, 3, 4, null]}
+${false} | ${true}    | ${false}   | ${[4, null, 1, 2, null, 3, 4]} | ${[1, 2, 3]}
+${true}  | ${false}   | ${true}    | ${[4, null, 1, 2, null, 3, 4]} | ${[null, null, 1, 2, 3, 4]}
+${false} | ${false}   | ${true}    | ${[4, null, 1, 2, null, 3, 4]} | ${[null, null, 1, 2, 3]}
+${true}  | ${false}   | ${false}   | ${[4, null, 1, 2, null, 3, 4]} | ${[1, 2, 3, 4, null, null]}
+${false} | ${false}   | ${false}   | ${[4, null, 1, 2, null, 3, 4]} | ${[1, 2, 3, null, null]}
+`('Series.dropDuplicates($keep, $nullsEqual, $nullsFirst)', ({keep, nullsEqual, nullsFirst, data, expected}) => {
+  const s      = Series.new({type: new Int32, data});
+  const result = s.dropDuplicates(keep, nullsEqual, nullsFirst);
+  expect([...result]).toEqual(expected);
+});

--- a/modules/cudf/test/dataframe/join-tests.ts
+++ b/modules/cudf/test/dataframe/join-tests.ts
@@ -411,7 +411,7 @@ describe('DataFrame.join({how="right"}) ', () => {
     expect(result.names).toEqual(expect.arrayContaining(['a', 'b', 'c']));
 
     // Sorting is just to get 1-1 agreement with order of pd/cudf results
-    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'AFTER'}});
+    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'after'}});
 
     expect([...sorted_result.get('b')]).toEqual([0, 0, 1, 1, 3]);
     expect([...sorted_result.get('a')]).toEqual([1, 2, 3, 4, null]);
@@ -424,7 +424,7 @@ describe('DataFrame.join({how="right"}) ', () => {
     expect(result.names).toEqual(expect.arrayContaining(['a', 'b']));
 
     // Sorting is just to get 1-1 agreement with order of pd/cudf results
-    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'AFTER'}});
+    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'after'}});
 
     expect([...sorted_result.get('a')]).toEqual([0, 0, 10, 10, 30]);
     expect([...sorted_result.get('b')]).toEqual([0, 0, 1, 1, 3]);
@@ -436,7 +436,7 @@ describe('DataFrame.join({how="right"}) ', () => {
     expect(result.names).toEqual(expect.arrayContaining(['a', 'b', 'a_L']));
 
     // Sorting is just to get 1-1 agreement with order of pd/cudf results
-    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'AFTER'}});
+    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'after'}});
 
     expect([...sorted_result.get('b')]).toEqual([0, 0, 1, 1, 3]);
     expect([...sorted_result.get('a_L')]).toEqual([1, 2, 3, 4, null]);
@@ -449,7 +449,7 @@ describe('DataFrame.join({how="right"}) ', () => {
     expect(result.names).toEqual(expect.arrayContaining(['a', 'b', 'a_R']));
 
     // Sorting is just to get 1-1 agreement with order of pd/cudf results
-    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'AFTER'}});
+    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'after'}});
 
     expect([...sorted_result.get('b')]).toEqual([0, 0, 1, 1, 3]);
     expect([...sorted_result.get('a')]).toEqual([1, 2, 3, 4, null]);
@@ -463,7 +463,7 @@ describe('DataFrame.join({how="right"}) ', () => {
     expect(result.names).toEqual(expect.arrayContaining(['a_L', 'b', 'a_R']));
 
     // Sorting is just to get 1-1 agreement with order of pd/cudf results
-    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'AFTER'}});
+    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'after'}});
 
     expect([...sorted_result.get('b')]).toEqual([0, 0, 1, 1, 3]);
     expect([...sorted_result.get('a_L')]).toEqual([1, 2, 3, 4, null]);
@@ -489,7 +489,7 @@ describe('DataFrame.join({how="right"}) ', () => {
     expect(result.names).toEqual(expect.arrayContaining(['a', 'b', 'c']));
 
     // Sorting is just to get 1-1 agreement with order of pd/cudf results
-    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'AFTER'}});
+    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'after'}});
 
     expect([...sorted_result.get('b')]).toEqual([0, 0, 1, 1, 3]);
     expect([...sorted_result.get('a')]).toEqual([1, 2, 3, 4, null]);
@@ -519,7 +519,7 @@ describe('DataFrame.join({how="leftsemi"}) ', () => {
     expect(result.numColumns).toEqual(2);
     expect(result.names).toEqual(expect.arrayContaining(['a', 'b']));
 
-    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'AFTER'}});
+    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'after'}});
 
     expect([...sorted_result.get('b')]).toEqual([2]);
     expect([...sorted_result.get('a')]).toEqual([5]);
@@ -532,7 +532,7 @@ describe('DataFrame.join({how="leftanti"}) ', () => {
     expect(result.numColumns).toEqual(2);
     expect(result.names).toEqual(expect.arrayContaining(['a', 'b']));
 
-    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'AFTER'}});
+    const sorted_result = result.sortValues({b: {ascending: true, null_order: 'after'}});
 
     expect([...sorted_result.get('b')]).toEqual([0, 0, 1, 1]);
     expect([...sorted_result.get('a')]).toEqual([1, 2, 3, 4]);

--- a/modules/demo/client-server/components/server/cudf-utils.js
+++ b/modules/demo/client-server/components/server/cudf-utils.js
@@ -102,7 +102,7 @@ async function groupBy(df, by, aggregation, columns, query_dict, res) {
     trips = trips.sortValues({
       [by]: {
         ascending: true,
-        null_order: 'AFTER'
+        null_order: 'after'
       }
     });
 


### PR DESCRIPTION
This PR includes the following changes:

- Moves `drop_duplicates` method from `column` to `table` in C++
- Adds `dropDuplicates` to `Series` and `DataFrame` TS classes
- Adds unit tests for `Series.dropDuplicates` and `DataFrame.dropDuplicates`
- Updates `Series.unique` to use `Series.dropDuplicates`
- Fixes a bug that Paul noticed in `_dropNullsRows` and `_dropNansRows` where the wrong values were being pushed to the `column_indices` arrays (1a89f1e)
- Updates `NullOrder` enum values case (~~ee94e25~~ 7d68261)