### PR TITLE
[FEA] Added bindings for `head` and `tail`

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -55,7 +55,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `gt`                 |         ✅          |
 | `hash_encode`        |                     |
 | `hash_values`        |                     |
-| `head`               |                     |
+| `head`               |         ✅          |
 | `interleave_columns` |                     |
 | `isin`               |                     |
 | `isna`               |    ✅ (`isNull`)    |
@@ -121,7 +121,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `std`                |         ✅          |
 | `sub`                |         ✅          |
 | `sum`                |         ✅          |
-| `tail`               |                     |
+| `tail`               |         ✅          |
 | `take`               |    ✅ (`gather`)    |
 | `tan`                |         ✅          |
 | `tile`               |                     |
@@ -172,7 +172,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `groupby`            |                     |                     |                     |
 | `hash_encode`        |                     |                     |                     |
 | `hash_values`        |                     |                     |                     |
-| `head`               |                     |                     |                     |
+| `head`               |         ✅          |         ✅          |         ✅          |
 | `interleave_columns` |                     |                     |                     |
 | `isin`               |                     |                     |                     |
 | `isna`               |    ✅ (`isNull`)    |    ✅ (`isNull`)    |    ✅ (`isNull`)    |
@@ -208,7 +208,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `skew`               |                     |                     |                     |
 | `sort_index`         |                     |                     |                     |
 | `sort_values`        |                     |                     |                     |
-| `tail`               |                     |                     |                     |
+| `tail`               |         ✅          |         ✅          |         ✅          |
 | `take`               |    ✅ (`gather`)    |    ✅ (`gather`)    |    ✅ (`gather`)    |
 | `tile`               |                     |                     |                     |
 | `to_array`           |                     |                     |                     |
@@ -268,7 +268,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `from_pandas`        |                    |
 | `from_records`       |                    |
 | `hash_columns`       |                    |
-| `head`               |                    |
+| `head`               |         ✅         |
 | `info`               |                    |
 | `insert`             |                    |
 | `interleave_columns` |                    |
@@ -338,7 +338,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `std`                |                    |
 | `sub`                |                    |
 | `sum`                |                    |
-| `tail`               |                    |
+| `tail`               |         ✅         |
 | `take`               |   ✅ (`gather`)    |
 | `tan`                |         ✅         |
 | `tile`               |                    |

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -457,7 +457,7 @@ export class DataFrame<T extends TypeMap = any> {
    *
    * @example
    * ```typescript
-   * import {DataFrame, Series} from '@rapidsai/cudf';
+   * import {DataFrame, Series, Int32} from '@rapidsai/cudf';
    *
    * const df = new DataFrame({
    *   a: Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 5, 6]}),
@@ -490,7 +490,7 @@ export class DataFrame<T extends TypeMap = any> {
    *
    * @example
    * ```typescript
-   * import {DataFrame, Series} from '@rapidsai/cudf';
+   * import {DataFrame, Series, Int32} from '@rapidsai/cudf';
    *
    * const df = new DataFrame({
    *   a: Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 5, 6]}),

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -634,7 +634,7 @@ export class AbstractSeries<T extends DataType = any> {
    *
    * @example
    * ```typescript
-   * import {Series, Int32} from '@rapidsai/cudf';
+   * import {Series} from '@rapidsai/cudf';
    *
    * const a = Series.new([4, 6, 8, 10, 12, 1, 2]);
    * const b = Series.new(["foo", "bar", "test"]);
@@ -660,7 +660,7 @@ export class AbstractSeries<T extends DataType = any> {
    *
    * @example
    * ```typescript
-   * import {Series, Int32} from '@rapidsai/cudf';
+   * import {Series} from '@rapidsai/cudf';
    *
    * const a = Series.new([4, 6, 8, 10, 12, 1, 2]);
    * const b = Series.new(["foo", "bar", "test"]);

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -628,6 +628,59 @@ export class AbstractSeries<T extends DataType = any> {
   }
 
   /**
+   * Returns the first n rows.
+   *
+   * @param n The number of rows to return.
+   *
+   * @example
+   * ```typescript
+   * import {Series, Int32} from '@rapidsai/cudf';
+   *
+   * const a = Series.new([4, 6, 8, 10, 12, 1, 2]);
+   * const b = Series.new(["foo", "bar", "test"]);
+   *
+   * a.head(); // [4, 6, 8, 10, 12]
+   * b.head(1); // ["foo"]
+   * a.head(-1); // throws index out of bounds error
+   * ```
+   */
+  head(n = 5): Series<T> {
+    if (n < 0) { throw new Error('Index provided is out of bounds'); }
+    const selection = Series.new({
+      type: new Int32,
+      data: Array.from({length: n < this._col.length ? n : this._col.length}, (_, i) => i)
+    });
+    return this.__construct(this._col.gather(selection._col));
+  }
+
+  /**
+   * Returns the last n rows.
+   *
+   * @param n The number of rows to return.
+   *
+   * @example
+   * ```typescript
+   * import {Series, Int32} from '@rapidsai/cudf';
+   *
+   * const a = Series.new([4, 6, 8, 10, 12, 1, 2]);
+   * const b = Series.new(["foo", "bar", "test"]);
+   *
+   * a.tail(); // [8, 10, 12, 1, 2]
+   * b.tail(1); // ["test"]
+   * a.tail(-1); // throws index out of bounds error
+   * ```
+   */
+  tail(n = 5): Series<T> {
+    if (n < 0) { throw new Error('Index provided is out of bounds'); }
+    const length    = n < this._col.length ? n : this._col.length;
+    const selection = Series.new({
+      type: new Int32,
+      data: Array.from({length: length}, (_, i) => this._col.length - length + i)
+    });
+    return this.__construct(this._col.gather(selection._col));
+  }
+
+  /**
    * Scatters single value into this Series according to provided indices.
    *
    * @param value A column of values to be scattered in to this Series

--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -233,6 +233,72 @@ test('DataFrame.gather (indices)', () => {
   expect([...rb]).toEqual([...expected_b]);
 });
 
+describe('Dataframe.head', () => {
+  const a  = Series.new([0, 1, 2, 3, 4, 5, 6]);
+  const b  = Series.new([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]);
+  const c  = Series.new(['foo', null, null, 'bar', null, null, 'foo']);
+  const df = new DataFrame({'a': a, 'b': b, 'c': c});
+
+  test('default index', () => {
+    const result = df.head();
+    expect(result.numRows).toEqual(5);
+    expect([...result.get('a')]).toEqual([0, 1, 2, 3, 4]);
+    expect([...result.get('b')]).toEqual([0.0, 1.1, 2.2, 3.3, 4.4]);
+    expect([...result.get('c')]).toEqual(['foo', null, null, 'bar', null]);
+  });
+
+  test('invalid index', () => { expect(() => df.head(-1)).toThrowError(); });
+
+  test('providing index', () => {
+    const result = df.head(2);
+    expect(result.numRows).toEqual(2);
+    expect([...result.get('a')]).toEqual([0, 1]);
+    expect([...result.get('b')]).toEqual([0.0, 1.1]);
+    expect([...result.get('c')]).toEqual(['foo', null]);
+  });
+
+  test('index longer than length of series', () => {
+    const result = df.head(25);
+    expect(result.numRows).toEqual(7);
+    expect([...result.get('a')]).toEqual([...a]);
+    expect([...result.get('b')]).toEqual([...b]);
+    expect([...result.get('c')]).toEqual([...c]);
+  });
+});
+
+describe('Dataframe.tail', () => {
+  const a  = Series.new([0, 1, 2, 3, 4, 5, 6]);
+  const b  = Series.new([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]);
+  const c  = Series.new(['foo', null, null, 'bar', null, null, 'foo']);
+  const df = new DataFrame({'a': a, 'b': b, 'c': c});
+
+  test('default index', () => {
+    const result = df.tail();
+    expect(result.numRows).toEqual(5);
+    expect([...result.get('a')]).toEqual([2, 3, 4, 5, 6]);
+    expect([...result.get('b')]).toEqual([2.2, 3.3, 4.4, 5.5, 6.6]);
+    expect([...result.get('c')]).toEqual([null, 'bar', null, null, 'foo']);
+  });
+
+  test('invalid index', () => { expect(() => df.tail(-1)).toThrowError(); });
+
+  test('providing index', () => {
+    const result = df.tail(2);
+    expect(result.numRows).toEqual(2);
+    expect([...result.get('a')]).toEqual([5, 6]);
+    expect([...result.get('b')]).toEqual([5.5, 6.6]);
+    expect([...result.get('c')]).toEqual([null, 'foo']);
+  });
+
+  test('index longer than length of series', () => {
+    const result = df.tail(25);
+    expect(result.numRows).toEqual(7);
+    expect([...result.get('a')]).toEqual([...a]);
+    expect([...result.get('b')]).toEqual([...b]);
+    expect([...result.get('c')]).toEqual([...c]);
+  });
+});
+
 test('DataFrame groupBy (single)', () => {
   const a   = Series.new({type: new Int32, data: [1, 2, 3, 1, 2, 2, 1, 3, 3, 2]});
   const b   = Series.new({type: new Float32, data: [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]});

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -200,27 +200,15 @@ test('Series.gather', () => {
 });
 
 describe('Series.head', () => {
-  test('default index', () => {
-    const col =
-      Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
-    expect([...col.head()]).toEqual([0, 1, 2, 3, 4]);
-  });
+  const col = Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
 
-  test('invalid index', () => {
-    const col =
-      Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
-    expect(() => col.head(-1)).toThrowError();
-  });
+  test('default index', () => { expect([...col.head()]).toEqual([0, 1, 2, 3, 4]); });
 
-  test('providing index', () => {
-    const col =
-      Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
-    expect([...col.head(8)]).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
-  });
+  test('invalid index', () => { expect(() => col.head(-1)).toThrowError(); });
+
+  test('providing index', () => { expect([...col.head(8)]).toEqual([0, 1, 2, 3, 4, 5, 6, 7]); });
 
   test('index longer than length of series', () => {
-    const col =
-      Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
     expect([...col.head(25)]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
 });

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -199,6 +199,46 @@ test('Series.gather', () => {
   expect([...result]).toEqual([...selection]);
 });
 
+describe('Series.head', () => {
+  test('default index', () => {
+    const col =
+      Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
+    expect([...col.head()]).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test('invalid index', () => {
+    const col =
+      Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
+    expect(() => col.head(-1)).toThrowError();
+  });
+
+  test('providing index', () => {
+    const col =
+      Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
+    expect([...col.head(8)]).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  test('index longer than length of series', () => {
+    const col =
+      Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
+    expect([...col.head(25)]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+});
+
+describe('Series.tail', () => {
+  const col = Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
+
+  test('default index', () => { expect([...col.tail()]).toEqual([5, 6, 7, 8, 9]); });
+
+  test('invalid index', () => { expect(() => col.tail(-1)).toThrowError(); });
+
+  test('providing index', () => { expect([...col.tail(8)]).toEqual([2, 3, 4, 5, 6, 7, 8, 9]); });
+
+  test('index longer than length of series', () => {
+    expect([...col.tail(25)]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+});
+
 test('Series.scatter (series)', () => {
   const col     = Series.new({type: new Int32, data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]});
   const values  = Series.new({type: new Int32, data: [200, 400, 500, 800]});


### PR DESCRIPTION
Using `gather` seemed like the logical choice to me.

**Changes**
- Added series `head` & `tail`
- Added dataframe `head` & `tail`
- Added tests for both
