### PR TITLE
[FEA] Added series `reverse`

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -97,7 +97,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `repeat`             |                       |
 | `replace`            |                       |
 | `reset_index`        |                       |
-| `reverse`            |                       |
+| `reverse`            |          ✅           |
 | `rfloordiv`          |                       |
 | `rmod`               |                       |
 | `rmul`               |                       |
@@ -197,7 +197,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `repeat`             |                       |                       |                       |
 | `replace`            |                       |                       |                       |
 | `reset_index`        |                       |                       |                       |
-| `reverse`            |                       |                       |                       |
+| `reverse`            |          ✅           |          ✅           |          ✅           |
 | `rolling`            |                       |                       |                       |
 | `sample`             |                       |                       |                       |
 | `scatter_by_map`     |                       |                       |                       |

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -620,7 +620,10 @@ export class AbstractSeries<T extends DataType = any> {
    * Series.new([false, true]).reverse() // [true, false]
    * ```
    */
-  reverse(): Series<T> { return Series.new({type: this.type, data: [...this].reverse()}); }
+  reverse(): Series<T> {
+    return this.gather(
+      Series.sequence({type: new Int32, size: this.length, step: -1, init: this.length - 1}));
+  }
 
   /**
    * Return a sub-selection of this Series using the specified integral indices.

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -606,6 +606,23 @@ export class AbstractSeries<T extends DataType = any> {
   }
 
   /**
+   * Returns a new series with reversed elements.
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * // Float64Series
+   * Series.new([1, 2, 3]).reverse() // [3, 2, 1]
+   * // StringSeries
+   * Series.new(["foo", "bar"]).reverse() // ["bar", "foo"]
+   * // Bool8Series
+   * Series.new([false, true]).reverse() // [true, false]
+   * ```
+   */
+  reverse(): Series<T> { return Series.new({type: this.type, data: [...this].reverse()}); }
+
+  /**
    * Return a sub-selection of this Series using the specified integral indices.
    *
    * @param selection A Series of 8/16/32-bit signed or unsigned integer indices.

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -452,6 +452,13 @@ test('FloatSeries.nansToNulls', () => {
   expect(col.nullCount).toEqual(0);
 });
 
+test('Series.reverse', () => {
+  const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const col   = Series.new(array);
+
+  expect([...col.reverse()]).toEqual(array.reverse());
+});
+
 describe.each([new Int32, new Float32, new Float64])('Series.sequence({type=%p,, ...})', (typ) => {
   test('no step', () => {
     const col = Series.sequence({type: typ, size: 10, init: 0});


### PR DESCRIPTION
Seemed reasonable to just take advantage of the spread operator, and use the built in `reverse()` in js.