### PR TITLE
Implement cumulative reductions for Series

### DIFF
--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -97,6 +97,10 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Column::variance>("var"),
                        InstanceMethod<&Column::std>("std"),
                        InstanceMethod<&Column::quantile>("quantile"),
+                       InstanceMethod<&Column::cummax>("cummax"),
+                       InstanceMethod<&Column::cummin>("cummin"),
+                       InstanceMethod<&Column::cumprod>("cumprod"),
+                       InstanceMethod<&Column::cumsum>("cumsum"),
                        // column/strings/json.cpp
                        InstanceMethod<&Column::get_json_object>("getJSONObject"),
                        // column/replacement.cpp

--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -97,10 +97,10 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Column::variance>("var"),
                        InstanceMethod<&Column::std>("std"),
                        InstanceMethod<&Column::quantile>("quantile"),
-                       InstanceMethod<&Column::cummax>("cummax"),
-                       InstanceMethod<&Column::cummin>("cummin"),
-                       InstanceMethod<&Column::cumprod>("cumprod"),
-                       InstanceMethod<&Column::cumsum>("cumsum"),
+                       InstanceMethod<&Column::cumulative_max>("cumulativeMax"),
+                       InstanceMethod<&Column::cumulative_min>("cumulativeMin"),
+                       InstanceMethod<&Column::cumulative_product>("cumulativeProduct"),
+                       InstanceMethod<&Column::cumulative_sum>("cumulativeSum"),
                        // column/strings/json.cpp
                        InstanceMethod<&Column::get_json_object>("getJSONObject"),
                        // column/replacement.cpp

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -1037,7 +1037,7 @@ export interface Column<T extends DataType = any> {
    *   memory.
    * @returns The cumulative max of all the values in this Column.
    */
-  cummax(memoryResource?: MemoryResource): Column<T>;
+  cumulativeMax(memoryResource?: MemoryResource): Column<T>;
 
   /**
    * Compute the cumulative min of all values in this Column.
@@ -1046,7 +1046,7 @@ export interface Column<T extends DataType = any> {
    *   memory.
    * @returns The cumulative min of all the values in this Column.
    */
-  cummin(memoryResource?: MemoryResource): Column<T>;
+  cumulativeMin(memoryResource?: MemoryResource): Column<T>;
 
   /**
    * Compute the cumulative product of all values in this Column.
@@ -1055,7 +1055,7 @@ export interface Column<T extends DataType = any> {
    *   memory.
    * @returns The cumulative product of all the values in this Column.
    */
-  cumprod(memoryResource?: MemoryResource): Column<T>;
+  cumulativeProduct(memoryResource?: MemoryResource): Column<T>;
 
   /**
    * Compute the cumulative sum of all values in this Column.
@@ -1064,7 +1064,7 @@ export interface Column<T extends DataType = any> {
    *   memory.
    * @returns The cumulative sum of all the values in this Column.
    */
-  cumsum(memoryResource?: MemoryResource): Column<T>;
+  cumulativeSum(memoryResource?: MemoryResource): Column<T>;
 
   /**
    * drop NA values from the column if column is of floating-type

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -1031,6 +1031,42 @@ export interface Column<T extends DataType = any> {
   quantile(q?: number, interpolation?: Interpolation, memoryResource?: MemoryResource): number;
 
   /**
+   * Compute the cumulative max of all values in this Column.
+   *
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   * @returns The cumulative max of all the values in this Column.
+   */
+  cummax(memoryResource?: MemoryResource): Column<T>;
+
+  /**
+   * Compute the cumulative min of all values in this Column.
+   *
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   * @returns The cumulative min of all the values in this Column.
+   */
+  cummin(memoryResource?: MemoryResource): Column<T>;
+
+  /**
+   * Compute the cumulative product of all values in this Column.
+   *
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   * @returns The cumulative product of all the values in this Column.
+   */
+  cumprod(memoryResource?: MemoryResource): Column<T>;
+
+  /**
+   * Compute the cumulative sum of all values in this Column.
+   *
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   * @returns The cumulative sum of all the values in this Column.
+   */
+  cumsum(memoryResource?: MemoryResource): Column<T>;
+
+  /**
    * drop NA values from the column if column is of floating-type
    * values and contains NA values
    * @param memoryResource The optional MemoryResource used to allocate the result column's device

--- a/modules/cudf/src/column/reduction.cpp
+++ b/modules/cudf/src/column/reduction.cpp
@@ -191,7 +191,7 @@ Napi::Value Column::quantile(Napi::CallbackInfo const& info) {
   return Napi::Value::From(info.Env(), quantile(args[0], args[1], args[2]));
 }
 
-Column::wrapper_t Column::cummax(rmm::mr::device_memory_resource* mr) const {
+Column::wrapper_t Column::cumulative_max(rmm::mr::device_memory_resource* mr) const {
   return scan(cudf::make_max_aggregation(),
               // following cudf, scan type and null policy always use these values
               cudf::scan_type::INCLUSIVE,
@@ -199,12 +199,12 @@ Column::wrapper_t Column::cummax(rmm::mr::device_memory_resource* mr) const {
               mr);
 }
 
-Napi::Value Column::cummax(Napi::CallbackInfo const& info) {
-  return Napi::Value::From(info.Env(),
-                           cummax(NapiToCPP(info[0]).operator rmm::mr::device_memory_resource*()));
+Napi::Value Column::cumulative_max(Napi::CallbackInfo const& info) {
+  return Napi::Value::From(
+    info.Env(), cumulative_max(NapiToCPP(info[0]).operator rmm::mr::device_memory_resource*()));
 }
 
-Column::wrapper_t Column::cummin(rmm::mr::device_memory_resource* mr) const {
+Column::wrapper_t Column::cumulative_min(rmm::mr::device_memory_resource* mr) const {
   return scan(cudf::make_min_aggregation(),
               // following cudf, scan type and null policy always use these values
               cudf::scan_type::INCLUSIVE,
@@ -212,11 +212,11 @@ Column::wrapper_t Column::cummin(rmm::mr::device_memory_resource* mr) const {
               mr);
 }
 
-Napi::Value Column::cummin(Napi::CallbackInfo const& info) {
-  return cummin(NapiToCPP(info[0]).operator rmm::mr::device_memory_resource*())->Value();
+Napi::Value Column::cumulative_min(Napi::CallbackInfo const& info) {
+  return cumulative_min(NapiToCPP(info[0]).operator rmm::mr::device_memory_resource*())->Value();
 }
 
-Column::wrapper_t Column::cumprod(rmm::mr::device_memory_resource* mr) const {
+Column::wrapper_t Column::cumulative_product(rmm::mr::device_memory_resource* mr) const {
   return scan(cudf::make_product_aggregation(),
               // following cudf, scan type and null policy always use these values
               cudf::scan_type::INCLUSIVE,
@@ -224,12 +224,12 @@ Column::wrapper_t Column::cumprod(rmm::mr::device_memory_resource* mr) const {
               mr);
 }
 
-Napi::Value Column::cumprod(Napi::CallbackInfo const& info) {
-  return Napi::Value::From(info.Env(),
-                           cumprod(NapiToCPP(info[0]).operator rmm::mr::device_memory_resource*()));
+Napi::Value Column::cumulative_product(Napi::CallbackInfo const& info) {
+  return Napi::Value::From(
+    info.Env(), cumulative_product(NapiToCPP(info[0]).operator rmm::mr::device_memory_resource*()));
 }
 
-Column::wrapper_t Column::cumsum(rmm::mr::device_memory_resource* mr) const {
+Column::wrapper_t Column::cumulative_sum(rmm::mr::device_memory_resource* mr) const {
   return scan(cudf::make_sum_aggregation(),
               // following cudf, scan type and null policy always use these values
               cudf::scan_type::INCLUSIVE,
@@ -237,9 +237,9 @@ Column::wrapper_t Column::cumsum(rmm::mr::device_memory_resource* mr) const {
               mr);
 }
 
-Napi::Value Column::cumsum(Napi::CallbackInfo const& info) {
-  return Napi::Value::From(info.Env(),
-                           cumsum(NapiToCPP(info[0]).operator rmm::mr::device_memory_resource*()));
+Napi::Value Column::cumulative_sum(Napi::CallbackInfo const& info) {
+  return Napi::Value::From(
+    info.Env(), cumulative_sum(NapiToCPP(info[0]).operator rmm::mr::device_memory_resource*()));
 }
 
 }  // namespace nv

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -32,6 +32,7 @@
 #include <cudf/unary.hpp>
 
 #include <rmm/device_buffer.hpp>
+#include "cudf/reduction.hpp"
 
 #include <napi.h>
 
@@ -227,6 +228,19 @@ struct Column : public EnvLocalObjectWrap<Column> {
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
   /**
+   * @copydoc cudf::scan(cudf::column_view const &col, std::unique_ptr<aggregation> const &agg,
+   * cudf::scan_type inclusive, cudf::null_policy null_handling, rmm::mr::device_memory_resource*
+   * mr)
+   *
+   * @return Column
+   */
+  Column::wrapper_t scan(
+    std::unique_ptr<cudf::aggregation> const& agg,
+    cudf::scan_type inclusive,
+    cudf::null_policy null_handling     = cudf::null_policy::EXCLUDE,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  /**
    * @copydoc cudf::sum(rmm::mr::device_memory_resource* mr)
    *
    * @return Scalar
@@ -316,6 +330,38 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Scalar::wrapper_t quantile(
     double q                            = 0.5,
     cudf::interpolation i               = cudf::interpolation::LINEAR,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  /**
+   * @brief Return the cumulative max
+   *
+   * @return Scalar
+   */
+  Column::wrapper_t cummax(
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  /**
+   * @brief Return the cumulative minimum
+   *
+   * @return Scalar
+   */
+  Column::wrapper_t cummin(
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  /**
+   * @brief Return the cumulative product
+   *
+   * @return Scalar
+   */
+  Column::wrapper_t cumprod(
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  /**
+   * @brief Return the cumulative sum
+   *
+   * @return Scalar
+   */
+  Column::wrapper_t cumsum(
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
   // column/binaryop.cpp
@@ -771,6 +817,10 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Napi::Value variance(Napi::CallbackInfo const& info);
   Napi::Value std(Napi::CallbackInfo const& info);
   Napi::Value quantile(Napi::CallbackInfo const& info);
+  Napi::Value cummax(Napi::CallbackInfo const& info);
+  Napi::Value cummin(Napi::CallbackInfo const& info);
+  Napi::Value cumprod(Napi::CallbackInfo const& info);
+  Napi::Value cumsum(Napi::CallbackInfo const& info);
 
   // column/strings/json.cpp
   Napi::Value get_json_object(Napi::CallbackInfo const& info);

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -337,7 +337,7 @@ struct Column : public EnvLocalObjectWrap<Column> {
    *
    * @return Scalar
    */
-  Column::wrapper_t cummax(
+  Column::wrapper_t cumulative_max(
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
   /**
@@ -345,7 +345,7 @@ struct Column : public EnvLocalObjectWrap<Column> {
    *
    * @return Scalar
    */
-  Column::wrapper_t cummin(
+  Column::wrapper_t cumulative_min(
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
   /**
@@ -353,7 +353,7 @@ struct Column : public EnvLocalObjectWrap<Column> {
    *
    * @return Scalar
    */
-  Column::wrapper_t cumprod(
+  Column::wrapper_t cumulative_product(
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
   /**
@@ -361,7 +361,7 @@ struct Column : public EnvLocalObjectWrap<Column> {
    *
    * @return Scalar
    */
-  Column::wrapper_t cumsum(
+  Column::wrapper_t cumulative_sum(
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
   // column/binaryop.cpp
@@ -817,10 +817,10 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Napi::Value variance(Napi::CallbackInfo const& info);
   Napi::Value std(Napi::CallbackInfo const& info);
   Napi::Value quantile(Napi::CallbackInfo const& info);
-  Napi::Value cummax(Napi::CallbackInfo const& info);
-  Napi::Value cummin(Napi::CallbackInfo const& info);
-  Napi::Value cumprod(Napi::CallbackInfo const& info);
-  Napi::Value cumsum(Napi::CallbackInfo const& info);
+  Napi::Value cumulative_max(Napi::CallbackInfo const& info);
+  Napi::Value cumulative_min(Napi::CallbackInfo const& info);
+  Napi::Value cumulative_product(Napi::CallbackInfo const& info);
+  Napi::Value cumulative_sum(Napi::CallbackInfo const& info);
 
   // column/strings/json.cpp
   Napi::Value get_json_object(Napi::CallbackInfo const& info);

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -477,7 +477,8 @@ export class AbstractSeries<T extends DataType = any> {
    * Series.new([true, true, true]).fill(false, 1) // [true, false, false]
    * ```
    */
-  fill(value: T, begin = 0, end = this.length, memoryResource?: MemoryResource): Series<T> {
+  fill(value: T['scalarType'], begin = 0, end = this.length, memoryResource?: MemoryResource):
+    Series<T> {
     return Series.new(
       this._col.fill(new Scalar({type: this.type, value}), begin, end, memoryResource));
   }
@@ -501,7 +502,7 @@ export class AbstractSeries<T extends DataType = any> {
    * Series.new([true, true, true]).fillInPlace(false, 1) // [true, false, false]
    * ```
    */
-  fillInPlace(value: T, begin = 0, end = this.length) {
+  fillInPlace(value: T['scalarType'], begin = 0, end = this.length) {
     this._col.fillInPlace(new Scalar({type: this.type, value}), begin, end);
     return this;
   }

--- a/modules/cudf/src/series/bool.ts
+++ b/modules/cudf/src/series/bool.ts
@@ -60,12 +60,12 @@ export class Bool8Series extends NumericSeries<Bool8> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([true, false, true])
    *
-   * a.cummax() // {true, true, true}
+   * a.cumulativeMax() // {true, true, true}
    * ```
    */
-  cummax(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeMax(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna);
-    return Series.new(result_series._col.cummax(memoryResource));
+    return Series.new(result_series._col.cumulativeMax(memoryResource));
   }
 
   /**
@@ -81,12 +81,12 @@ export class Bool8Series extends NumericSeries<Bool8> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([true, false, true])
    *
-   * a.cummin() // {true, false, false}
+   * a.cumulativeMin() // {true, false, false}
    * ```
    */
-  cummin(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeMin(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna);
-    return Series.new(result_series._col.cummin(memoryResource));
+    return Series.new(result_series._col.cumulativeMin(memoryResource));
   }
 
   /**
@@ -103,12 +103,12 @@ export class Bool8Series extends NumericSeries<Bool8> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([true, false, true])
    *
-   * a.cumprod() // {1n, 0n, 0n}
+   * a.cumulativeProduct() // {1n, 0n, 0n}
    * ```
    */
-  cumprod(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeProduct(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna).cast(new Int64, memoryResource);
-    return Series.new(result_series._col.cumprod(memoryResource));
+    return Series.new(result_series._col.cumulativeProduct(memoryResource));
   }
 
   /**
@@ -125,11 +125,11 @@ export class Bool8Series extends NumericSeries<Bool8> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([true, false, true])
    *
-   * a.cumsum() // {1n, 1n, 2n}
+   * a.cumulativeSum() // {1n, 1n, 2n}
    * ```
    */
-  cumsum(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeSum(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna).cast(new Int64, memoryResource);
-    return Series.new(result_series._col.cumsum(memoryResource));
+    return Series.new(result_series._col.cumulativeSum(memoryResource));
   }
 }

--- a/modules/cudf/src/series/bool.ts
+++ b/modules/cudf/src/series/bool.ts
@@ -16,7 +16,7 @@ import {Uint8ClampedBuffer} from '@nvidia/cuda';
 import {MemoryResource} from '@rapidsai/rmm';
 
 import {Series} from '../series';
-import {Bool8, Int64} from '../types/dtypes';
+import {Bool8, Int32, Int64} from '../types/dtypes';
 
 import {NumericSeries} from './numeric';
 
@@ -31,11 +31,20 @@ export class Bool8Series extends NumericSeries<Bool8> {
     return new Uint8ClampedBuffer(this._col.data).subarray(this.offset, this.offset + this.length);
   }
 
-protected _prepare_scan_series(skipna: boolean) {
-    if (skipna) { return this; }
+  protected _prepare_scan_series(skipna: boolean) {
+    if (skipna || !this.hasNulls) { return this; }
 
-    // TODO: skipna=false
-    return this;
+    const index = Series.sequence({type: new Int32, size: this.length, step: 1, init: 0});
+
+    const first = index.filter(this.isNull()).getValue(0)!;
+    const slice =
+      Series.sequence({type: new Int32, size: this.length - first, step: 1, init: first});
+
+    const copy = this.cast(this.type);
+    const mask = [...index.cast(new Bool8).fill(true).scatter(false, slice)];
+    copy.setNullMask(mask as any);
+
+    return copy;
   }
 
   /**

--- a/modules/cudf/src/series/bool.ts
+++ b/modules/cudf/src/series/bool.ts
@@ -31,7 +31,7 @@ export class Bool8Series extends NumericSeries<Bool8> {
     return new Uint8ClampedBuffer(this._col.data).subarray(this.offset, this.offset + this.length);
   }
 
-  _prepare_scan_series(skipna: boolean) {
+protected _prepare_scan_series(skipna: boolean) {
     if (skipna) { return this; }
 
     // TODO: skipna=false

--- a/modules/cudf/src/series/bool.ts
+++ b/modules/cudf/src/series/bool.ts
@@ -103,7 +103,7 @@ export class Bool8Series extends NumericSeries<Bool8> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([true, false, true])
    *
-   * a.cumprod() // {1n, 1n, 2n}
+   * a.cumprod() // {1n, 0n, 0n}
    * ```
    */
   cumprod(skipna = true, memoryResource?: MemoryResource) {
@@ -125,7 +125,7 @@ export class Bool8Series extends NumericSeries<Bool8> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([true, false, true])
    *
-   * a.cumsum() // {1n, 0n, 0n}
+   * a.cumsum() // {1n, 1n, 2n}
    * ```
    */
   cumsum(skipna = true, memoryResource?: MemoryResource) {

--- a/modules/cudf/src/series/float.ts
+++ b/modules/cudf/src/series/float.ts
@@ -161,10 +161,106 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
     return this._col.any(memoryResource);
   }
 
+  _prepare_scan_series(skipna: boolean) {
+    if (skipna) { return this.nansToNulls(); }
+
+    // TODO: skipna=false
+    return this;
+  }
+
+  /**
+   * Compute the cumulative max of all values in this Series.
+   *
+   * @param skipna The optional skipna if true drops NA and null values before computing
+   *   reduction,
+   * else if skipna is false, reduction is computed directly.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   * @returns The cumulative max of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([4, 2, 5, 1, 1])
+   *
+   * a.cummax() // {4, 4, 5, 5, 5}
+   * ```
+   */
+  cummax(skipna = true, memoryResource?: MemoryResource) {
+    const result_series = this._prepare_scan_series(skipna);
+    return Series.new(result_series._col.cummax(memoryResource) as Column<T>);
+  }
+
+  /**
+   * Compute the cumulative min of all values in this Series.
+   *
+   * @param skipna The optional skipna if true drops NA and null values before computing
+   *   reduction,
+   * else if skipna is false, reduction is computed directly.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   * @returns The cumulative min of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([4, 2, 5, 1, 1])
+   *
+   * a.cummin() // {4, 2, 2, 1, 1}
+   * ```
+   */
+  cummin(skipna = true, memoryResource?: MemoryResource) {
+    const result_series = this._prepare_scan_series(skipna);
+    return Series.new(result_series._col.cummin(memoryResource) as Column<T>);
+  }
+
+  /**
+   * Compute the cumulative product of all values in this Series.
+   *
+   * @param skipna The optional skipna if true drops NA and null values before computing
+   *   reduction,
+   * else if skipna is false, reduction is computed directly.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   * @returns The cumulative product of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([4, 2, 5, 1, 1])
+   *
+   * a.cumprod() // {4, 8, 40, 40, 40}
+   * ```
+   */
+  cumprod(skipna = true, memoryResource?: MemoryResource) {
+    const result_series = this._prepare_scan_series(skipna);
+    return Series.new(result_series._col.cumprod(memoryResource) as Column<T>);
+  }
+
+  /**
+   * Compute the cumulative sum of all values in this Series.
+   *
+   * @param skipna The optional skipna if true drops NA and null values before computing
+   *   reduction,
+   * else if skipna is false, reduction is computed directly.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   * @returns The cumulative sum of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([4, 2, 5, 1, 1])
+   *
+   * a.cumsum() // {4, 6, 11, 12, 13}
+   * ```
+   */
+  cumsum(skipna = true, memoryResource?: MemoryResource) {
+    const result_series = this._prepare_scan_series(skipna);
+    return Series.new(result_series._col.cumsum(memoryResource) as Column<T>);
+  }
+
   /**
    * Compute the mean of all values in this Series.
    *
-   * @param skipna The optional skipna if true drops NA and null values before computing reduction,
+   * @param skipna The optional skipna if true drops NA and null values before computing
+   *   reduction,
    * else if skipna is false, reduction is computed directly.
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
@@ -178,7 +274,8 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
   /**
    * Compute the median of all values in this Series.
    *
-   * @param skipna The optional skipna if true drops NA and null values before computing reduction,
+   * @param skipna The optional skipna if true drops NA and null values before computing
+   *   reduction,
    * else if skipna is false, reduction is computed directly.
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
@@ -193,8 +290,8 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
    * Compute the nunique of all values in this Series.
    *
    * @param dropna
-   * If true, NA/null values will not contribute to the count of unique values. If false, they will
-   * be included in the count.
+   * If true, NA/null values will not contribute to the count of unique values. If false, they
+   * will be included in the count.
    * @param memoryResource The optional MemoryResource used to allocate the result Series's device
    *   memory.
    * @returns The number of unqiue values in this Series.

--- a/modules/cudf/src/series/float.ts
+++ b/modules/cudf/src/series/float.ts
@@ -195,12 +195,12 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([4, 2, 5, 1, 1])
    *
-   * a.cummax() // {4, 4, 5, 5, 5}
+   * a.cumulativeMax() // {4, 4, 5, 5, 5}
    * ```
    */
-  cummax(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeMax(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna);
-    return Series.new(result_series._col.cummax(memoryResource) as Column<T>);
+    return Series.new(result_series._col.cumulativeMax(memoryResource) as Column<T>);
   }
 
   /**
@@ -217,12 +217,12 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([4, 2, 5, 1, 1])
    *
-   * a.cummin() // {4, 2, 2, 1, 1}
+   * a.cumulativeMin() // {4, 2, 2, 1, 1}
    * ```
    */
-  cummin(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeMin(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna);
-    return Series.new(result_series._col.cummin(memoryResource) as Column<T>);
+    return Series.new(result_series._col.cumulativeMin(memoryResource) as Column<T>);
   }
 
   /**
@@ -239,12 +239,12 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([4, 2, 5, 1, 1])
    *
-   * a.cumprod() // {4, 8, 40, 40, 40}
+   * a.cumulativeProduct() // {4, 8, 40, 40, 40}
    * ```
    */
-  cumprod(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeProduct(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna);
-    return Series.new(result_series._col.cumprod(memoryResource) as Column<T>);
+    return Series.new(result_series._col.cumulativeProduct(memoryResource) as Column<T>);
   }
 
   /**
@@ -261,12 +261,12 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([4, 2, 5, 1, 1])
    *
-   * a.cumsum() // {4, 6, 11, 12, 13}
+   * a.cumulativeSum() // {4, 6, 11, 12, 13}
    * ```
    */
-  cumsum(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeSum(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna);
-    return Series.new(result_series._col.cumsum(memoryResource) as Column<T>);
+    return Series.new(result_series._col.cumulativeSum(memoryResource) as Column<T>);
   }
 
   /**

--- a/modules/cudf/src/series/float.ts
+++ b/modules/cudf/src/series/float.ts
@@ -161,7 +161,7 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
     return this._col.any(memoryResource);
   }
 
-  _prepare_scan_series(skipna: boolean) {
+  protected _prepare_scan_series(skipna: boolean) {
     if (skipna) { return this.nansToNulls(); }
 
     // TODO: skipna=false

--- a/modules/cudf/src/series/integral.ts
+++ b/modules/cudf/src/series/integral.ts
@@ -190,7 +190,8 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
   bitInvert(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.bitInvert(memoryResource));
   }
-  _prepare_scan_series(skipna: boolean) {
+
+  protected _prepare_scan_series(skipna: boolean) {
     if (skipna) { return this; }
 
     // TODO: skipna=false

--- a/modules/cudf/src/series/integral.ts
+++ b/modules/cudf/src/series/integral.ts
@@ -190,6 +190,98 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
   bitInvert(memoryResource?: MemoryResource): Series<T> {
     return Series.new(this._col.bitInvert(memoryResource));
   }
+  _prepare_scan_series(skipna: boolean) {
+    if (skipna) { return this; }
+
+    // TODO: skipna=false
+    return this;
+  }
+
+  /**
+   * Compute the cumulative max of all values in this Series.
+   *
+   * @param skipna The optional skipna if true drops NA and null values before computing reduction,
+   * else if skipna is false, reduction is computed directly.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   * @returns The cumulative max of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([4, 2, 5, 1, 1])
+   *
+   * a.cummax() // {4, 4, 5, 5, 5}
+   * ```
+   */
+  cummax(skipna = true, memoryResource?: MemoryResource) {
+    const result_series = this._prepare_scan_series(skipna);
+    return Series.new(result_series._col.cummax(memoryResource));
+  }
+
+  /**
+   * Compute the cumulative min of all values in this Series.
+   *
+   * @param skipna The optional skipna if true drops NA and null values before computing reduction,
+   * else if skipna is false, reduction is computed directly.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   * @returns The cumulative min of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([4, 2, 5, 1, 1])
+   *
+   * a.cummin() // {4, 2, 2, 1, 1}
+   * ```
+   */
+  cummin(skipna = true, memoryResource?: MemoryResource) {
+    const result_series = this._prepare_scan_series(skipna);
+    return Series.new(result_series._col.cummin(memoryResource));
+  }
+
+  /**
+   * Compute the cumulative product of all values in this Series.
+   *
+   * @param skipna The optional skipna if true drops NA and null values before computing
+   *   reduction,
+   * else if skipna is false, reduction is computed directly.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   * @returns The cumulative product of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([4, 2, 5, 1, 1])
+   *
+   * a.cumprod() // {4, 8, 40, 40, 40}
+   * ```
+   */
+  cumprod(skipna = true, memoryResource?: MemoryResource) {
+    const result_series = this._prepare_scan_series(skipna);
+    return Series.new(result_series._col.cumprod(memoryResource));
+  }
+
+  /**
+   * Compute the cumulative sum of all values in this Series.
+   *
+   * @param skipna The optional skipna if true drops NA and null values before computing
+   *   reduction,
+   * else if skipna is false, reduction is computed directly.
+   * @param memoryResource The optional MemoryResource used to allocate the result Series's device
+   *   memory.
+   * @returns The cumulative sum of all the values in this Series.
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   * const a = Series.new([4, 2, 5, 1, 1])
+   *
+   * a.cumsum() // {4, 6, 11, 12, 13}
+   * ```
+   */
+  cumsum(skipna = true, memoryResource?: MemoryResource) {
+    const result_series = this._prepare_scan_series(skipna);
+    return Series.new(result_series._col.cumsum(memoryResource));
+  }
 }
 
 /**

--- a/modules/cudf/src/series/integral.ts
+++ b/modules/cudf/src/series/integral.ts
@@ -219,7 +219,7 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new([4, 2, 5, 1, 1])
+   * const a = Series.new([4, 2, 5, 1, 1]).cast(new Int32)
    *
    * a.cummax() // {4, 4, 5, 5, 5}
    * ```
@@ -240,7 +240,7 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new([4, 2, 5, 1, 1])
+   * const a = Series.new([4, 2, 5, 1, 1]).cast(new Int32)
    *
    * a.cummin() // {4, 2, 2, 1, 1}
    * ```
@@ -262,7 +262,7 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new([4, 2, 5, 1, 1])
+   * const a = Series.new([4, 2, 5, 1, 1]).cast(new Int32)
    *
    * a.cumprod() // {4, 8, 40, 40, 40}
    * ```
@@ -284,7 +284,7 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
-   * const a = Series.new([4, 2, 5, 1, 1])
+   * const a = Series.new([4, 2, 5, 1, 1]).cast(new Int32)
    *
    * a.cumsum() // {4, 6, 11, 12, 13}
    * ```

--- a/modules/cudf/src/series/integral.ts
+++ b/modules/cudf/src/series/integral.ts
@@ -221,12 +221,12 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([4, 2, 5, 1, 1]).cast(new Int32)
    *
-   * a.cummax() // {4, 4, 5, 5, 5}
+   * a.cumulativeMax() // {4, 4, 5, 5, 5}
    * ```
    */
-  cummax(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeMax(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna) as any;
-    return Series.new(result_series._col.cummax(memoryResource));
+    return Series.new(result_series._col.cumulativeMax(memoryResource));
   }
 
   /**
@@ -242,12 +242,12 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([4, 2, 5, 1, 1]).cast(new Int32)
    *
-   * a.cummin() // {4, 2, 2, 1, 1}
+   * a.cumulativeMin() // {4, 2, 2, 1, 1}
    * ```
    */
-  cummin(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeMin(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna) as any;
-    return Series.new(result_series._col.cummin(memoryResource));
+    return Series.new(result_series._col.cumulativeMin(memoryResource));
   }
 
   /**
@@ -264,12 +264,12 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([4, 2, 5, 1, 1]).cast(new Int32)
    *
-   * a.cumprod() // {4, 8, 40, 40, 40}
+   * a.cumulativeProduct() // {4, 8, 40, 40, 40}
    * ```
    */
-  cumprod(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeProduct(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna) as any;
-    return Series.new(result_series._col.cumprod(memoryResource));
+    return Series.new(result_series._col.cumulativeProduct(memoryResource));
   }
 
   /**
@@ -286,12 +286,12 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * import {Series} from '@rapidsai/cudf';
    * const a = Series.new([4, 2, 5, 1, 1]).cast(new Int32)
    *
-   * a.cumsum() // {4, 6, 11, 12, 13}
+   * a.cumulativeSum() // {4, 6, 11, 12, 13}
    * ```
    */
-  cumsum(skipna = true, memoryResource?: MemoryResource) {
+  cumulativeSum(skipna = true, memoryResource?: MemoryResource) {
     const result_series = this._prepare_scan_series(skipna) as any;
-    return Series.new(result_series._col.cumsum(memoryResource));
+    return Series.new(result_series._col.cumulativeSum(memoryResource));
   }
 }
 

--- a/modules/cudf/test/series/reduce/cummax-tests.ts
+++ b/modules/cudf/test/series/reduce/cummax-tests.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '../../jest-extensions';
+
+import {setDefaultAllocator} from '@nvidia/cuda';
+import {
+  Bool8,
+  Float32,
+  Float64,
+  Int16,
+  Int32,
+  Int64,
+  Int8,
+  Series,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint8
+} from '@rapidsai/cudf';
+import {DeviceBuffer} from '@rapidsai/rmm';
+
+setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength));
+
+const numbers        = [4, 2, null, 5, 1, 1];
+const float_with_NaN = [4, 2, NaN, 5, 1, 1];
+const bools          = [true, false, null, false, true];
+const bigints        = [4n, 2n, null, 5n, 1n, 1n];
+
+function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Float64>(
+  type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [4, 4, null, 5, 5, 5]  //
+                          : [4, 4, null, null, null, null];
+  expect([...Series.new({type, data}).cummax(skipna)]).toEqual(expected);
+}
+
+function testBigIntAny<T extends Int64|Uint64>(
+  type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [4n, 4n, null, 5n, 5n, 5n]  //
+                          : [4n, 4n, null, null, null, null];
+  expect([...Series.new({type, data}).cummax(skipna)]).toEqual(expected);
+}
+
+function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [true, true, null, true, true]  //
+                          : [true, false, null, null, null];
+
+  expect([...Series.new({type, data}).cummax(skipna)]).toEqual(expected);
+}
+
+describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
+  test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
+  test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
+  test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });
+  test('Int64', () => { testBigIntAny(new Int64, bigints, skipna); });
+  test('Uint8', () => { testNumberAny(new Uint8, numbers, skipna); });
+  test('Uint16', () => { testNumberAny(new Uint16, numbers, skipna); });
+  test('Uint32', () => { testNumberAny(new Uint32, numbers, skipna); });
+  test('Uint64', () => { testBigIntAny(new Uint64, bigints, skipna); });
+  test('Float32', () => { testNumberAny(new Float32, numbers, skipna); });
+  test('Float64', () => { testNumberAny(new Float64, numbers, skipna); });
+  test('Bool8', () => { testBooleanAny(new Bool8, bools, skipna); });
+  test('Float32', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
+  test('Float64', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
+});

--- a/modules/cudf/test/series/reduce/cummax-tests.ts
+++ b/modules/cudf/test/series/reduce/cummax-tests.ts
@@ -42,24 +42,24 @@ function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Fl
   type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [4, 4, null, 5, 5, 5]  //
                           : [4, 4, null, null, null, null];
-  expect([...Series.new({type, data}).cummax(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeMax(skipna)]).toEqual(expected);
 }
 
 function testBigIntAny<T extends Int64|Uint64>(
   type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [4n, 4n, null, 5n, 5n, 5n]  //
                           : [4n, 4n, null, null, null, null];
-  expect([...Series.new({type, data}).cummax(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeMax(skipna)]).toEqual(expected);
 }
 
 function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [true, true, null, true, true]  //
                           : [true, true, null, null, null];
 
-  expect([...Series.new({type, data}).cummax(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeMax(skipna)]).toEqual(expected);
 }
 
-describe.each([[true], [false]])('Series.cummax(skipna=%p)', (skipna) => {
+describe.each([[true], [false]])('Series.cumulativeMax(skipna=%p)', (skipna) => {
   test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
   test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
   test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });

--- a/modules/cudf/test/series/reduce/cummax-tests.ts
+++ b/modules/cudf/test/series/reduce/cummax-tests.ts
@@ -54,12 +54,12 @@ function testBigIntAny<T extends Int64|Uint64>(
 
 function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [true, true, null, true, true]  //
-                          : [true, false, null, null, null];
+                          : [true, true, null, null, null];
 
   expect([...Series.new({type, data}).cummax(skipna)]).toEqual(expected);
 }
 
-describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
+describe.each([[true], [false]])('Series.cummax(skipna=%p)', (skipna) => {
   test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
   test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
   test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });
@@ -71,6 +71,6 @@ describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
   test('Float32', () => { testNumberAny(new Float32, numbers, skipna); });
   test('Float64', () => { testNumberAny(new Float64, numbers, skipna); });
   test('Bool8', () => { testBooleanAny(new Bool8, bools, skipna); });
-  test('Float32', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
-  test('Float64', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
+  test('Float32-nan', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
+  test('Float64-nan', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
 });

--- a/modules/cudf/test/series/reduce/cummin-tests.ts
+++ b/modules/cudf/test/series/reduce/cummin-tests.ts
@@ -58,7 +58,7 @@ function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[]
   expect([...Series.new({type, data}).cummin(skipna)]).toEqual(expected);
 }
 
-describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
+describe.each([[true], [false]])('Series.cummin(skipna=%p)', (skipna) => {
   test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
   test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
   test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });
@@ -70,6 +70,6 @@ describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
   test('Float32', () => { testNumberAny(new Float32, numbers, skipna); });
   test('Float64', () => { testNumberAny(new Float64, numbers, skipna); });
   test('Bool8', () => { testBooleanAny(new Bool8, bools, skipna); });
-  test('Float32', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
-  test('Float64', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
+  test('Float32-nan', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
+  test('Float64-nan', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
 });

--- a/modules/cudf/test/series/reduce/cummin-tests.ts
+++ b/modules/cudf/test/series/reduce/cummin-tests.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '../../jest-extensions';
+
+import {setDefaultAllocator} from '@nvidia/cuda';
+import {
+  Bool8,
+  Float32,
+  Float64,
+  Int16,
+  Int32,
+  Int64,
+  Int8,
+  Series,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint8
+} from '@rapidsai/cudf';
+import {DeviceBuffer} from '@rapidsai/rmm';
+
+setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength));
+
+const numbers        = [4, 2, null, 5, 1, 1];
+const float_with_NaN = [4, 2, NaN, 5, 1, 1];
+const bools          = [true, false, null, false, true];
+const bigints        = [4n, 2n, null, 5n, 1n, 1n];
+
+function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Float64>(
+  type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [4, 2, null, 2, 1, 1]  //
+                          : [4, 2, null, null, null, null];
+  expect([...Series.new({type, data}).cummin(skipna)]).toEqual(expected);
+}
+
+function testBigIntAny<T extends Int64|Uint64>(
+  type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [4n, 2n, null, 2n, 1n, 1n]  //
+                          : [4n, 2n, null, null, null, null];
+  expect([...Series.new({type, data}).cummin(skipna)]).toEqual(expected);
+}
+
+function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [true, false, null, false, false]  //
+                          : [true, false, null, null, null];
+  expect([...Series.new({type, data}).cummin(skipna)]).toEqual(expected);
+}
+
+describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
+  test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
+  test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
+  test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });
+  test('Int64', () => { testBigIntAny(new Int64, bigints, skipna); });
+  test('Uint8', () => { testNumberAny(new Uint8, numbers, skipna); });
+  test('Uint16', () => { testNumberAny(new Uint16, numbers, skipna); });
+  test('Uint32', () => { testNumberAny(new Uint32, numbers, skipna); });
+  test('Uint64', () => { testBigIntAny(new Uint64, bigints, skipna); });
+  test('Float32', () => { testNumberAny(new Float32, numbers, skipna); });
+  test('Float64', () => { testNumberAny(new Float64, numbers, skipna); });
+  test('Bool8', () => { testBooleanAny(new Bool8, bools, skipna); });
+  test('Float32', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
+  test('Float64', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
+});

--- a/modules/cudf/test/series/reduce/cummin-tests.ts
+++ b/modules/cudf/test/series/reduce/cummin-tests.ts
@@ -42,23 +42,23 @@ function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Fl
   type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [4, 2, null, 2, 1, 1]  //
                           : [4, 2, null, null, null, null];
-  expect([...Series.new({type, data}).cummin(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeMin(skipna)]).toEqual(expected);
 }
 
 function testBigIntAny<T extends Int64|Uint64>(
   type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [4n, 2n, null, 2n, 1n, 1n]  //
                           : [4n, 2n, null, null, null, null];
-  expect([...Series.new({type, data}).cummin(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeMin(skipna)]).toEqual(expected);
 }
 
 function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [true, false, null, false, false]  //
                           : [true, false, null, null, null];
-  expect([...Series.new({type, data}).cummin(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeMin(skipna)]).toEqual(expected);
 }
 
-describe.each([[true], [false]])('Series.cummin(skipna=%p)', (skipna) => {
+describe.each([[true], [false]])('Series.cumulativeMin(skipna=%p)', (skipna) => {
   test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
   test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
   test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });

--- a/modules/cudf/test/series/reduce/cumprod-tests.ts
+++ b/modules/cudf/test/series/reduce/cumprod-tests.ts
@@ -42,23 +42,23 @@ function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Fl
   type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [4, 8, null, 40, 40, 40]  //
                           : [4, 8, null, null, null, null];
-  expect([...Series.new({type, data}).cumprod(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeProduct(skipna)]).toEqual(expected);
 }
 
 function testBigIntAny<T extends Int64|Uint64>(
   type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [4n, 8n, null, 40n, 40n, 40n]  //
                           : [4n, 8n, null, null, null, null];
-  expect([...Series.new({type, data}).cumprod(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeProduct(skipna)]).toEqual(expected);
 }
 
 function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [1n, 0n, null, 0n, 0n]  //
                           : [1n, 0n, null, null, null];
-  expect([...Series.new({type, data}).cumprod(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeProduct(skipna)]).toEqual(expected);
 }
 
-describe.each([[true], [false]])('Series.cumprod(skipna=%p)', (skipna) => {
+describe.each([[true], [false]])('Series.cumulativeProduct(skipna=%p)', (skipna) => {
   test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
   test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
   test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });

--- a/modules/cudf/test/series/reduce/cumprod-tests.ts
+++ b/modules/cudf/test/series/reduce/cumprod-tests.ts
@@ -58,7 +58,7 @@ function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[]
   expect([...Series.new({type, data}).cumprod(skipna)]).toEqual(expected);
 }
 
-describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
+describe.each([[true], [false]])('Series.cumprod(skipna=%p)', (skipna) => {
   test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
   test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
   test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });
@@ -70,6 +70,6 @@ describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
   test('Float32', () => { testNumberAny(new Float32, numbers, skipna); });
   test('Float64', () => { testNumberAny(new Float64, numbers, skipna); });
   test('Bool8', () => { testBooleanAny(new Bool8, bools, skipna); });
-  test('Float32', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
-  test('Float64', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
+  test('Float32-nan', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
+  test('Float64-nan', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
 });

--- a/modules/cudf/test/series/reduce/cumprod-tests.ts
+++ b/modules/cudf/test/series/reduce/cumprod-tests.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '../../jest-extensions';
+
+import {setDefaultAllocator} from '@nvidia/cuda';
+import {
+  Bool8,
+  Float32,
+  Float64,
+  Int16,
+  Int32,
+  Int64,
+  Int8,
+  Series,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint8
+} from '@rapidsai/cudf';
+import {DeviceBuffer} from '@rapidsai/rmm';
+
+setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength));
+
+const numbers        = [4, 2, null, 5, 1, 1];
+const float_with_NaN = [4, 2, NaN, 5, 1, 1];
+const bools          = [true, false, null, false, true];
+const bigints        = [4n, 2n, null, 5n, 1n, 1n];
+
+function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Float64>(
+  type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [4, 8, null, 40, 40, 40]  //
+                          : [4, 8, null, null, null, null];
+  expect([...Series.new({type, data}).cumprod(skipna)]).toEqual(expected);
+}
+
+function testBigIntAny<T extends Int64|Uint64>(
+  type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [4n, 8n, null, 40n, 40n, 40n]  //
+                          : [4n, 8n, null, null, null, null];
+  expect([...Series.new({type, data}).cumprod(skipna)]).toEqual(expected);
+}
+
+function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [1n, 0n, null, 0n, 0n]  //
+                          : [1n, 0n, null, null, null];
+  expect([...Series.new({type, data}).cumprod(skipna)]).toEqual(expected);
+}
+
+describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
+  test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
+  test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
+  test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });
+  test('Int64', () => { testBigIntAny(new Int64, bigints, skipna); });
+  test('Uint8', () => { testNumberAny(new Uint8, numbers, skipna); });
+  test('Uint16', () => { testNumberAny(new Uint16, numbers, skipna); });
+  test('Uint32', () => { testNumberAny(new Uint32, numbers, skipna); });
+  test('Uint64', () => { testBigIntAny(new Uint64, bigints, skipna); });
+  test('Float32', () => { testNumberAny(new Float32, numbers, skipna); });
+  test('Float64', () => { testNumberAny(new Float64, numbers, skipna); });
+  test('Bool8', () => { testBooleanAny(new Bool8, bools, skipna); });
+  test('Float32', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
+  test('Float64', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
+});

--- a/modules/cudf/test/series/reduce/cumsum-tests.ts
+++ b/modules/cudf/test/series/reduce/cumsum-tests.ts
@@ -58,7 +58,7 @@ function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[]
   expect([...Series.new({type, data}).cumsum(skipna)]).toEqual(expected);
 }
 
-describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
+describe.each([[true], [false]])('Series.cumsum(skipna=%p)', (skipna) => {
   test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
   test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
   test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });
@@ -70,6 +70,6 @@ describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
   test('Float32', () => { testNumberAny(new Float32, numbers, skipna); });
   test('Float64', () => { testNumberAny(new Float64, numbers, skipna); });
   test('Bool8', () => { testBooleanAny(new Bool8, bools, skipna); });
-  test('Float32', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
-  test('Float64', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
+  test('Float32-nan', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
+  test('Float64-nan', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
 });

--- a/modules/cudf/test/series/reduce/cumsum-tests.ts
+++ b/modules/cudf/test/series/reduce/cumsum-tests.ts
@@ -42,23 +42,23 @@ function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Fl
   type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [4, 6, null, 11, 12, 13]  //
                           : [4, 6, null, null, null, null];
-  expect([...Series.new({type, data}).cumsum(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeSum(skipna)]).toEqual(expected);
 }
 
 function testBigIntAny<T extends Int64|Uint64>(
   type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [4n, 6n, null, 11n, 12n, 13n]  //
                           : [4n, 6n, null, null, null, null];
-  expect([...Series.new({type, data}).cumsum(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeSum(skipna)]).toEqual(expected);
 }
 
 function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[], skipna = true) {
   const expected = skipna ? [1n, 1n, null, 1n, 2n]  //
                           : [1n, 1n, null, null, null];
-  expect([...Series.new({type, data}).cumsum(skipna)]).toEqual(expected);
+  expect([...Series.new({type, data}).cumulativeSum(skipna)]).toEqual(expected);
 }
 
-describe.each([[true], [false]])('Series.cumsum(skipna=%p)', (skipna) => {
+describe.each([[true], [false]])('Series.cumulativeSum(skipna=%p)', (skipna) => {
   test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
   test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
   test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });

--- a/modules/cudf/test/series/reduce/cumsum-tests.ts
+++ b/modules/cudf/test/series/reduce/cumsum-tests.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '../../jest-extensions';
+
+import {setDefaultAllocator} from '@nvidia/cuda';
+import {
+  Bool8,
+  Float32,
+  Float64,
+  Int16,
+  Int32,
+  Int64,
+  Int8,
+  Series,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint8
+} from '@rapidsai/cudf';
+import {DeviceBuffer} from '@rapidsai/rmm';
+
+setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength));
+
+const numbers        = [4, 2, null, 5, 1, 1];
+const float_with_NaN = [4, 2, NaN, 5, 1, 1];
+const bools          = [true, false, null, false, true];
+const bigints        = [4n, 2n, null, 5n, 1n, 1n];
+
+function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Float64>(
+  type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [4, 6, null, 11, 12, 13]  //
+                          : [4, 6, null, null, null, null];
+  expect([...Series.new({type, data}).cumsum(skipna)]).toEqual(expected);
+}
+
+function testBigIntAny<T extends Int64|Uint64>(
+  type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [4n, 6n, null, 11n, 12n, 13n]  //
+                          : [4n, 6n, null, null, null, null];
+  expect([...Series.new({type, data}).cumsum(skipna)]).toEqual(expected);
+}
+
+function testBooleanAny<T extends Bool8>(type: T, data: (T['scalarType']|null)[], skipna = true) {
+  const expected = skipna ? [1n, 1n, null, 1n, 2n]  //
+                          : [1n, 1n, null, null, null];
+  expect([...Series.new({type, data}).cumsum(skipna)]).toEqual(expected);
+}
+
+describe.each([[true]])('Series.cumsum(skipna=%p)', (skipna) => {
+  test('Int8', () => { testNumberAny(new Int8, numbers, skipna); });
+  test('Int16', () => { testNumberAny(new Int16, numbers, skipna); });
+  test('Int32', () => { testNumberAny(new Int32, numbers, skipna); });
+  test('Int64', () => { testBigIntAny(new Int64, bigints, skipna); });
+  test('Uint8', () => { testNumberAny(new Uint8, numbers, skipna); });
+  test('Uint16', () => { testNumberAny(new Uint16, numbers, skipna); });
+  test('Uint32', () => { testNumberAny(new Uint32, numbers, skipna); });
+  test('Uint64', () => { testBigIntAny(new Uint64, bigints, skipna); });
+  test('Float32', () => { testNumberAny(new Float32, numbers, skipna); });
+  test('Float64', () => { testNumberAny(new Float64, numbers, skipna); });
+  test('Bool8', () => { testBooleanAny(new Bool8, bools, skipna); });
+  test('Float32', () => { testNumberAny(new Float32, float_with_NaN, skipna); });
+  test('Float64', () => { testNumberAny(new Float64, float_with_NaN, skipna); });
+});


### PR DESCRIPTION
This PR implements `cummax`, `cummin`, `cumprod`, and `cumsum` for `Series`

Currently `skipna=true` is finished, the `skipna=false` case is still TODO (some additional helpers need to be added)