### PR TITLE
[FIX] Remove unused declared import

### DIFF
--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -17,7 +17,6 @@ import {
   Bool8,
   DataFrame,
   Float32,
-  Float64,
   GroupByMultiple,
   GroupBySingle,
   Int32,


### PR DESCRIPTION
```
Warning: You are running with an unsupported TypeScript version! TypeDoc supports 3.9, 4.0, 4.1, 4.2
Error: modules/cudf/test/cudf-data-frame-tests.ts:20:3 - error TS6133: 'Float64' is declared but its value is never read.

20   Float64,
     ~~~~~~~

Error: Process completed with exit code 3.
```

noticed this when github tried to build last PR.