### PR TITLE
[FIX] Mark off series `sortValues` in BINDINGS.md

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -116,7 +116,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `sin`                |          ✅           |
 | `skew`               |          ✅           |
 | `sort_index`         |                       |
-| `sort_values`        |                       |
+| `sort_values`        |   ✅ (`sortValues`)   |
 | `sqrt`               |          ✅           |
 | `std`                |          ✅           |
 | `sub`                |          ✅           |
@@ -207,7 +207,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `shift`              |                       |                       |                       |
 | `skew`               |                       |                       |                       |
 | `sort_index`         |                       |                       |                       |
-| `sort_values`        |                       |                       |                       |
+| `sort_values`        |   ✅ (`sortValues`)   |   ✅ (`sortValues`)   |   ✅ (`sortValues`)   |
 | `tail`               |          ✅           |          ✅           |          ✅           |
 | `take`               |     ✅ (`gather`)     |     ✅ (`gather`)     |     ✅ (`gather`)     |
 | `tile`               |                       |                       |                       |


### PR DESCRIPTION
Was checking out the implementation for `nlargest` and saw it used the `sort_values` method internally in CUDF. Then noticed `sortValues` wasn't marked off in the `BINDINGS.md` even though it has proper implementation and tests.

https://github.com/rapidsai/node-rapids/blob/5f222ffaebe80f6fde2635316f38acfb748b7cec/modules/cudf/src/series.ts#L936