### PR TITLE
[FEA] Swap out `ccache` for `sccache`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,5 +12,14 @@ CUDA_VERSION=11.2.2
 # `nvidia/cudagl` base image Ubuntu version
 LINUX_VERSION=ubuntu20.04
 
-# Path where cuDF should store its runtime-compiled JIT kernels
-LIBCUDF_KERNEL_CACHE_PATH=/home/$USER/dev/rapids/node-rapids/modules/.cache/jit
+# Optional S3 region for shared sccache
+SCCACHE_REGION=<AWS region>
+
+# Optional S3 bucket for shared sccache
+SCCACHE_BUCKET=<bucket name>
+
+# Optional S3 access id for shared sccache
+AWS_ACCESS_KEY_ID=<AWS Access Key Id>
+
+# Optional S3 secret key for shared sccache
+AWS_SECRET_ACCESS_KEY=<AWS Secret Key>

--- a/.env.sample
+++ b/.env.sample
@@ -13,13 +13,13 @@ CUDA_VERSION=11.2.2
 LINUX_VERSION=ubuntu20.04
 
 # Optional S3 region for shared sccache
-SCCACHE_REGION=<AWS region>
+SCCACHE_REGION=us-west-2
 
 # Optional S3 bucket for shared sccache
-SCCACHE_BUCKET=<bucket name>
+SCCACHE_BUCKET=node-rapids-sccache
 
 # Optional S3 access id for shared sccache
-AWS_ACCESS_KEY_ID=<AWS Access Key Id>
+# AWS_ACCESS_KEY_ID=<AWS Access Key Id>
 
 # Optional S3 secret key for shared sccache
-AWS_SECRET_ACCESS_KEY=<AWS Secret Key>
+# AWS_SECRET_ACCESS_KEY=<AWS Secret Key>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-common-service-settings: &common_service_settings
   env_file: .env
   tty: true
   network_mode: "host"
-  working_dir: "${PWD}"
+  working_dir: "/opt/node-rapids"
   build: &common_build_settings
     context: .
     args: &common_build_args
@@ -20,8 +20,8 @@ x-common-service-settings: &common_service_settings
     XAUTHORITY: "${XAUTHORITY:-}"
     XDG_SESSION_TYPE: "${XDG_SESSION_TYPE:-}"
     NVIDIA_DRIVER_CAPABILITIES: "all"
-    LIBCUDF_KERNEL_CACHE_PATH: "${PWD}/modules/.cache/jit"
-    CCACHE_CONFIGPATH: "${PWD}/modules/.cache/ccache/ccache.conf"
+    LIBCUDF_KERNEL_CACHE_PATH: "/opt/node-rapids/modules/.cache/jit"
+    CCACHE_CONFIGPATH: "/opt/node-rapids/modules/.cache/ccache/ccache.conf"
   deploy:
     resources:
       reservations:
@@ -40,7 +40,7 @@ services:
         <<: *common_build_args
         BASE_IMAGE: nvidia/cudagl:${CUDA_VERSION:-11.2.2}-runtime-${LINUX_VERSION:-ubuntu20.04}
     volumes:
-      - &workdir "${PWD}:${PWD}:rw"
+      - &workdir "${PWD}:/opt/node-rapids:rw"
       - &etc_fonts "/etc/fonts:/etc/fonts:ro"
       - &x11_socket "/tmp/.X11-unix:/tmp/.X11-unix:rw"
       - &usr_share_fonts "/usr/share/fonts:/usr/share/fonts:ro"
@@ -61,7 +61,7 @@ services:
         BASE_IMAGE: nvidia/cudagl:${CUDA_VERSION:-11.2.2}-devel-${LINUX_VERSION:-ubuntu20.04}
     environment:
       <<: *common_environment_variables
-      DOCKER_WORKDIR: "${PWD}"
+      DOCKER_WORKDIR: "/opt/node-rapids"
     volumes:
       - *workdir
       - *etc_fonts
@@ -88,7 +88,7 @@ services:
         BASE_IMAGE: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.2.2}-devel-${LINUX_VERSION:-ubuntu20.04}-amd64
     environment:
       <<: *common_environment_variables
-      DOCKER_WORKDIR: "${PWD}"
+      DOCKER_WORKDIR: "/opt/node-rapids"
       QT_AUTO_SCREEN_SCALE_FACTOR: 0
       XDG_RUNTIME_DIR: "${XDG_RUNTIME_DIR:-/run/user/$UID}"
       DBUS_SESSION_BUS_ADDRESS: "${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$UID/bus}"
@@ -149,7 +149,7 @@ services:
       - *usr_share_icons
     environment:
       <<: *common_environment_variables
-      DOCKER_WORKDIR: "${PWD}"
+      DOCKER_WORKDIR: "/opt/node-rapids"
       # Build SASS and PTX for CUDA architecture sm_72
       CUDAARCHS: "${CUDAARCHS:-72-real}"
       PARALLEL_LEVEL: "${PARALLEL_LEVEL:-2}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,6 @@ services:
         BASE_IMAGE: nvidia/cudagl:${CUDA_VERSION:-11.2.2}-devel-${LINUX_VERSION:-ubuntu20.04}
     environment:
       <<: *common_environment_variables
-      DOCKER_WORKDIR: "/opt/node-rapids"
     volumes:
       - *workdir
       - *etc_fonts
@@ -88,7 +87,6 @@ services:
         BASE_IMAGE: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.2.2}-devel-${LINUX_VERSION:-ubuntu20.04}-amd64
     environment:
       <<: *common_environment_variables
-      DOCKER_WORKDIR: "/opt/node-rapids"
       QT_AUTO_SCREEN_SCALE_FACTOR: 0
       XDG_RUNTIME_DIR: "${XDG_RUNTIME_DIR:-/run/user/$UID}"
       DBUS_SESSION_BUS_ADDRESS: "${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$UID/bus}"
@@ -149,7 +147,6 @@ services:
       - *usr_share_icons
     environment:
       <<: *common_environment_variables
-      DOCKER_WORKDIR: "/opt/node-rapids"
       # Build SASS and PTX for CUDA architecture sm_72
       CUDAARCHS: "${CUDAARCHS:-72-real}"
       PARALLEL_LEVEL: "${PARALLEL_LEVEL:-2}"

--- a/dockerfiles/devel.Dockerfile
+++ b/dockerfiles/devel.Dockerfile
@@ -145,7 +145,7 @@ export HISTCONTROL=ignoreboth;\n\
 # Change the file location because certain bash sessions truncate .bash_history file upon close.\n\
 # http://superuser.com/questions/575479/bash-history-truncated-to-500-lines-on-each-login\n\
 export HISTFILE=/opt/node-rapids/modules/.cache/.eternal_bash_history;\n\
-touch $HISTFILE;\n\
+touch \$HISTFILE;\n\
 # flush commands to .bash_history immediately\n\
 export PROMPT_COMMAND=\"history -a; \$PROMPT_COMMAND\";\n\
 "' >> /home/node/.bashrc \

--- a/dockerfiles/devel.Dockerfile
+++ b/dockerfiles/devel.Dockerfile
@@ -145,6 +145,7 @@ export HISTCONTROL=ignoreboth;\n\
 # Change the file location because certain bash sessions truncate .bash_history file upon close.\n\
 # http://superuser.com/questions/575479/bash-history-truncated-to-500-lines-on-each-login\n\
 export HISTFILE=/opt/node-rapids/modules/.cache/.eternal_bash_history;\n\
+mkdir -p \$(dirname \$HISTFILE);\n\
 touch \$HISTFILE;\n\
 # flush commands to .bash_history immediately\n\
 export PROMPT_COMMAND=\"history -a; \$PROMPT_COMMAND\";\n\

--- a/dockerfiles/devel.Dockerfile
+++ b/dockerfiles/devel.Dockerfile
@@ -42,8 +42,8 @@ deb-src  http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -c
     libtinfo5 libncursesw5 \
     # Install gdb, lldb (for llnode), and clangd for C++ intellisense and debugging in the container
     gdb lldb-${LLDB_VERSION} clangd-${CLANGD_VERSION} clang-format-${CLANG_FORMAT_VERSION} \
-    # ccache dependencies
-    unzip automake autoconf libb2-dev libzstd-dev \
+    # sccache dependencies
+    cargo \
     # CMake dependencies
     curl libssl-dev libcurl4-openssl-dev zlib1g-dev \
     # X11 dependencies
@@ -101,22 +101,6 @@ RUN cd /tmp \
     --parallel=$PARALLEL_LEVEL \
  && make install -j$PARALLEL_LEVEL \
  && cd /tmp && rm -rf /tmp/cmake-$CMAKE_VERSION*
-
-ARG CCACHE_VERSION=4.1
-
- # Install ccache
-RUN cd /tmp \
- && curl -fsSLO --compressed https://github.com/ccache/ccache/releases/download/v$CCACHE_VERSION/ccache-$CCACHE_VERSION.tar.gz -o /tmp/ccache-$CCACHE_VERSION.tar.gz \
- && tar -xvzf /tmp/ccache-$CCACHE_VERSION.tar.gz && cd /tmp/ccache-$CCACHE_VERSION \
- && mkdir -p /tmp/ccache-$CCACHE_VERSION/build \
- && cd /tmp/ccache-$CCACHE_VERSION/build \
- && cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DZSTD_FROM_INTERNET=ON \
-    -DENABLE_TESTING=OFF \
-    /tmp/ccache-$CCACHE_VERSION \
- && make install -j$PARALLEL_LEVEL \
- && cd /tmp && rm -rf /tmp/ccache-$CCACHE_VERSION*
 
 ARG NODE_VERSION
 ENV NODE_VERSION=$NODE_VERSION
@@ -188,5 +172,9 @@ SHELL ["/bin/bash", "-c"]
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER node
+
+RUN cargo install sccache
+
+ENV PATH="$PATH:/home/node/.cargo/bin"
 
 CMD ["/bin/bash", "-l"]

--- a/dockerfiles/devel.Dockerfile
+++ b/dockerfiles/devel.Dockerfile
@@ -142,16 +142,13 @@ RUN useradd --uid $UID --user-group ${ADDITIONAL_GROUPS} --shell /bin/bash --cre
 export HISTSIZE=-1;\n\
 export HISTFILESIZE=-1;\n\
 export HISTCONTROL=ignoreboth;\n\
-# flush commands to .bash_history immediately\n\
-export PROMPT_COMMAND=\"history -a; \$PROMPT_COMMAND\";\n\
 # Change the file location because certain bash sessions truncate .bash_history file upon close.\n\
 # http://superuser.com/questions/575479/bash-history-truncated-to-500-lines-on-each-login\n\
-if [ -n \"\${DOCKER_WORKDIR}\" ]; then\n\
-    export HISTFILE=\"\${DOCKER_WORKDIR}/modules/.cache/.eternal_bash_history\";\n\
-fi\n\
+export HISTFILE=/opt/node-rapids/modules/.cache/.eternal_bash_history;\n\
+touch $HISTFILE;\n\
+# flush commands to .bash_history immediately\n\
+export PROMPT_COMMAND=\"history -a; \$PROMPT_COMMAND\";\n\
 "' >> /home/node/.bashrc \
- # Modify the entrypoint script to export the entrypoint as a DOCKER_WORKDIR env var
- && sed -ri 's/exec "\$@"/export DOCKER_WORKDIR="\$(pwd)";\nexec "\$@"/g' /usr/local/bin/docker-entrypoint.sh \
  && mkdir -p /etc/bash_completion.d \
  # add npm completions
  && npm completion > /etc/bash_completion.d/npm \

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 
-option(NODE_RAPIDS_USE_CCACHE "Enable caching compilation results with ccache" ON)
+option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
 ###################################################################################################

--- a/modules/core/cmake/Modules/ConfigureCUML.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUML.cmake
@@ -56,8 +56,10 @@ function(find_and_configure_cuml VERSION)
 
         CPMFindPackage(NAME     cuml
             VERSION             ${VERSION}
-            GIT_REPOSITORY      https://github.com/rapidsai/cuml.git
-            GIT_TAG             branch-${MAJOR_AND_MINOR}
+            # GIT_REPOSITORY      https://github.com/rapidsai/cuml.git
+            # GIT_TAG             branch-${MAJOR_AND_MINOR}
+            GIT_REPOSITORY      https://github.com/trxcllnt/cuml.git
+            GIT_TAG             fix/raft-knn-changes
             GIT_SHALLOW         TRUE
             UPDATE_DISCONNECTED FALSE
             SOURCE_SUBDIR       cpp

--- a/modules/core/cmake/Modules/ConfigureCXX.cmake
+++ b/modules/core/cmake/Modules/ConfigureCXX.cmake
@@ -21,39 +21,26 @@ if(UNIX AND NOT APPLE)
     set(LINUX TRUE)
 endif()
 
-if(NODE_RAPIDS_USE_CCACHE)
-    find_program(CCACHE_PROGRAM_PATH ccache)
-    if(CCACHE_PROGRAM_PATH)
-        message(STATUS "Using ccache: ${CCACHE_PROGRAM_PATH}")
-        set(CCACHE_COMMAND CACHE STRING "${CCACHE_PROGRAM_PATH}")
-        if(DEFINED ENV{CCACHE_DIR})
-            message(STATUS "Using ccache directory: $ENV{CCACHE_DIR}")
-            set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM_PATH}")
+if(NODE_RAPIDS_USE_SCCACHE)
+    find_program(SCCACHE_PROGRAM_PATH sccache)
+    if(SCCACHE_PROGRAM_PATH)
+        message(STATUS "Using sccache: ${SCCACHE_PROGRAM_PATH}")
+        set(CCACHE_COMMAND CACHE STRING "${SCCACHE_PROGRAM_PATH}")
+        if(DEFINED ENV{SCCACHE_DIR})
+            message(STATUS "Using sccache directory: $ENV{SCCACHE_DIR}")
+            set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${SCCACHE_PROGRAM_PATH}")
         else()
             execute_process(COMMAND node -p
-                            "require('@rapidsai/core').project_root_dir_path"
+                            "require('@rapidsai/core').sccache_path"
                             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                            OUTPUT_VARIABLE NODE_RAPIDS_BASE_DIR
+                            OUTPUT_VARIABLE NODE_RAPIDS_CMAKE_SCCACHE_DIR
                             OUTPUT_STRIP_TRAILING_WHITESPACE)
-            execute_process(COMMAND node -p
-                            "require('@rapidsai/core').cmake_modules_path"
-                            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                            OUTPUT_VARIABLE NODE_RAPIDS_CMAKE_MODULES_PATH
-                            OUTPUT_STRIP_TRAILING_WHITESPACE)
-            execute_process(COMMAND node -p
-                            "require('@rapidsai/core').ccache_path"
-                            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                            OUTPUT_VARIABLE NODE_RAPIDS_CMAKE_CCACHE_DIR
-                            OUTPUT_STRIP_TRAILING_WHITESPACE)
-            message(STATUS "Using ccache directory: ${NODE_RAPIDS_CMAKE_CCACHE_DIR}")
-            # Write or update the ccache configuration file
-            configure_file("${NODE_RAPIDS_CMAKE_MODULES_PATH}/ccache.conf.in" "${NODE_RAPIDS_CMAKE_CCACHE_DIR}/ccache.conf")
-            set(ENV{CCACHE_CONFIGPATH} "${NODE_RAPIDS_CMAKE_CCACHE_DIR}/ccache.conf")
+            message(STATUS "Using sccache directory: ${NODE_RAPIDS_CMAKE_SCCACHE_DIR}")
             set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE
-                "CCACHE_CONFIGPATH=${NODE_RAPIDS_CMAKE_CCACHE_DIR}/ccache.conf ${CCACHE_PROGRAM_PATH}")
-        endif(DEFINED ENV{CCACHE_DIR})
-    endif(CCACHE_PROGRAM_PATH)
-endif(NODE_RAPIDS_USE_CCACHE)
+                "SCCACHE_DIR=${NODE_RAPIDS_CMAKE_SCCACHE_DIR} ${SCCACHE_PROGRAM_PATH}")
+        endif(DEFINED ENV{SCCACHE_DIR})
+    endif(SCCACHE_PROGRAM_PATH)
+endif(NODE_RAPIDS_USE_SCCACHE)
 
 execute_process(COMMAND node -p
                 "require('@rapidsai/core').cpp_core_include_path"

--- a/modules/core/cmake/Modules/ConfigureRMM.cmake
+++ b/modules/core/cmake/Modules/ConfigureRMM.cmake
@@ -18,6 +18,8 @@ function(find_and_configure_rmm VERSION)
 
     include(get_cpm)
 
+    include(ConfigureThrust)
+
     _set_package_dir_if_exists(rmm rmm)
     _set_package_dir_if_exists(spdlog spdlog)
     _set_package_dir_if_exists(Thrust thrust)

--- a/modules/core/cmake/Modules/ConfigureThrust.cmake
+++ b/modules/core/cmake/Modules/ConfigureThrust.cmake
@@ -1,0 +1,38 @@
+#=============================================================================
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+function(find_and_configure_thrust VERSION)
+    # We only want to set `UPDATE_DISCONNECTED` while
+    # the GIT tag hasn't moved from the last time we cloned
+    set(cpm_thrust_disconnect_update "UPDATE_DISCONNECTED TRUE")
+    set(CPM_THRUST_CURRENT_VERSION ${VERSION} CACHE STRING "version of thrust we checked out")
+    if(NOT VERSION VERSION_EQUAL CPM_THRUST_CURRENT_VERSION)
+        set(CPM_THRUST_CURRENT_VERSION ${VERSION} CACHE STRING "version of thrust we checked out" FORCE)
+        set(cpm_thrust_disconnect_update "")
+    endif()
+
+    CPMAddPackage(NAME  Thrust
+        VERSION         ${VERSION}
+        GIT_REPOSITORY  https://github.com/NVIDIA/thrust.git
+        GIT_TAG         ${VERSION}
+        GIT_SHALLOW     TRUE
+        ${cpm_thrust_disconnect_update}
+        PATCH_COMMAND   patch --reject-file=- -p1 -N < ${CMAKE_CURRENT_LIST_DIR}/thrust.patch || true
+    )
+
+endfunction()
+
+find_and_configure_thrust(1.12.0)

--- a/modules/core/cmake/Modules/ccache.conf.in
+++ b/modules/core/cmake/Modules/ccache.conf.in
@@ -1,9 +1,0 @@
-max_size=0
-hash_dir=false
-# let ccache preserve C++ comments, because some of them may be meaningful to the compiler
-keep_comments_cpp=true
-base_dir=@NODE_RAPIDS_BASE_DIR@
-cache_dir=@NODE_RAPIDS_CMAKE_CCACHE_DIR@
-compiler_check=%compiler% --version
-# Uncomment to debug ccache preprocessor errors/cache misses
-# log_file=@NODE_RAPIDS_CMAKE_CCACHE_DIR@/ccache.log

--- a/modules/core/cmake/Modules/thrust.patch
+++ b/modules/core/cmake/Modules/thrust.patch
@@ -1,0 +1,83 @@
+diff --git a/thrust/system/cuda/detail/sort.h b/thrust/system/cuda/detail/sort.h
+index 1ffeef0..5e80800 100644
+--- a/thrust/system/cuda/detail/sort.h
++++ b/thrust/system/cuda/detail/sort.h
+@@ -108,7 +108,7 @@ namespace __merge_sort {
+     key_type key2 = keys_shared[keys2_beg];
+
+
+-#pragma unroll
++#pragma unroll 1
+     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
+     {
+       bool p = (keys2_beg < keys2_end) &&
+@@ -311,10 +311,10 @@ namespace __merge_sort {
+       void stable_odd_even_sort(key_type (&keys)[ITEMS_PER_THREAD],
+                                 item_type (&items)[ITEMS_PER_THREAD])
+       {
+-#pragma unroll
++#pragma unroll 1
+         for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+         {
+-#pragma unroll
++#pragma unroll 1
+           for (int j = 1 & i; j < ITEMS_PER_THREAD - 1; j += 2)
+           {
+             if (compare_op(keys[j + 1], keys[j]))
+@@ -350,7 +350,7 @@ namespace __merge_sort {
+         // each thread has  sorted keys_loc
+         // merge sort keys_loc in shared memory
+         //
+-#pragma unroll
++#pragma unroll 1
+         for (int coop = 2; coop <= BLOCK_THREADS; coop *= 2)
+         {
+           sync_threadblock();
+@@ -479,7 +479,7 @@ namespace __merge_sort {
+           // and fill the remainig keys with it
+           //
+           key_type max_key = keys_loc[0];
+-#pragma unroll
++#pragma unroll 1
+           for (int ITEM = 1; ITEM < ITEMS_PER_THREAD; ++ITEM)
+           {
+             if (ITEMS_PER_THREAD * tid + ITEM < num_remaining)
+diff a/cub/device/dispatch/dispatch_radix_sort.cuh b/cub/device/dispatch/dispatch_radix_sort.cuh
+index 41eb1d2..f2893b4 100644
+--- a/cub/device/dispatch/dispatch_radix_sort.cuh
++++ b/cub/device/dispatch/dispatch_radix_sort.cuh
+@@ -723,7 +723,7 @@ struct DeviceRadixSortPolicy
+
+
+     /// SM60 (GP100)
+-    struct Policy600 : ChainedPolicy<600, Policy600, Policy500>
++    struct Policy600 : ChainedPolicy<600, Policy600, Policy600>
+     {
+         enum {
+             PRIMARY_RADIX_BITS      = (sizeof(KeyT) > 1) ? 7 : 5,    // 6.9B 32b keys/s (Quadro P100)
+diff a/cub/device/dispatch/dispatch_reduce.cuh b/cub/device/dispatch/dispatch_reduce.cuh
+index f6aee45..dd64301 100644
+--- a/cub/device/dispatch/dispatch_reduce.cuh
++++ b/cub/device/dispatch/dispatch_reduce.cuh
+@@ -284,7 +284,7 @@ struct DeviceReducePolicy
+     };
+
+     /// SM60
+-    struct Policy600 : ChainedPolicy<600, Policy600, Policy350>
++    struct Policy600 : ChainedPolicy<600, Policy600, Policy600>
+     {
+         // ReducePolicy (P100: 591 GB/s @ 64M 4B items; 583 GB/s @ 256M 1B items)
+         typedef AgentReducePolicy<
+diff a/cub/device/dispatch/dispatch_scan.cuh b/cub/device/dispatch/dispatch_scan.cuh
+index c0c6d59..937ee31 100644
+--- a/cub/device/dispatch/dispatch_scan.cuh
++++ b/cub/device/dispatch/dispatch_scan.cuh
+@@ -178,7 +178,7 @@ struct DeviceScanPolicy
+     };
+
+     /// SM600
+-    struct Policy600 : ChainedPolicy<600, Policy600, Policy520>
++    struct Policy600 : ChainedPolicy<600, Policy600, Policy600>
+     {
+         typedef AgentScanPolicy<
+                 128, 15,                                        ///< Threads per block, items per thread

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -20,7 +20,7 @@ export const modules_path = Path.resolve(__dirname, '..', '..', '..');
 
 export const project_root_dir_path = Path.resolve(modules_path, '..');
 
-export const ccache_path = Path.resolve(modules_path, '.cache', 'ccache');
+export const sccache_path = Path.resolve(modules_path, '.cache', 'sccache');
 
 export const cpm_source_cache_path = Path.resolve(modules_path, '.cache', 'cpm');
 

--- a/modules/cuda/CMakeLists.txt
+++ b/modules/cuda/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 
-option(NODE_RAPIDS_USE_CCACHE "Enable caching compilation results with ccache" ON)
+option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 
 ###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------

--- a/modules/cudf/CMakeLists.txt
+++ b/modules/cudf/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 
-option(NODE_RAPIDS_USE_CCACHE "Enable caching compilation results with ccache" ON)
+option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
 set(RMM_VERSION "21.08.00")

--- a/modules/cugraph/CMakeLists.txt
+++ b/modules/cugraph/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 
-option(NODE_RAPIDS_USE_CCACHE "Enable caching compilation results with ccache" ON)
+option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
 set(RMM_VERSION "21.08.00")

--- a/modules/cuml/CMakeLists.txt
+++ b/modules/cuml/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 
-option(NODE_RAPIDS_USE_CCACHE "Enable caching compilation results with ccache" ON)
+option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
 set(RMM_VERSION "21.08.00")

--- a/modules/cuspatial/CMakeLists.txt
+++ b/modules/cuspatial/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 
-option(NODE_RAPIDS_USE_CCACHE "Enable caching compilation results with ccache" ON)
+option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
 set(RMM_VERSION "21.08.00")

--- a/modules/glfw/CMakeLists.txt
+++ b/modules/glfw/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 
-option(NODE_RAPIDS_USE_CCACHE "Enable caching compilation results with ccache" ON)
+option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(NODE_GLFW_STATIC_LINK "Statically link GLEW and GLFW libraries" OFF)
 
 # Set OpenGL_GL_PREFERENCE to "GLVND"

--- a/modules/rmm/CMakeLists.txt
+++ b/modules/rmm/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 
-option(NODE_RAPIDS_USE_CCACHE "Enable caching compilation results with ccache" ON)
+option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
 set(RMM_VERSION "21.08.00")

--- a/modules/webgl/CMakeLists.txt
+++ b/modules/webgl/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 
-option(NODE_RAPIDS_USE_CCACHE "Enable caching compilation results with ccache" ON)
+option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(NODE_WEBGL_STATIC_LINK "Statically link GLEW and GLFW libraries" OFF)
 
 # Set OpenGL_GL_PREFERENCE to "GLVND"


### PR DESCRIPTION
Swaps out `ccache` for `sccache`, allowing us to share the common build cache via something like AWS S3 or GCP.