### PR TITLE
Convert strict not equals to not equals in tests

### DIFF
--- a/modules/rmm/test/memory_resource/current-device-resource-tests.ts
+++ b/modules/rmm/test/memory_resource/current-device-resource-tests.ts
@@ -33,7 +33,7 @@ describe.each(memoryResourceTestConfigs)(`%s`, (_, {createMemoryResource}) => {
       expect(getCurrentDeviceResource()).toBe(mr);
       new DeviceBuffer(sizes['2_MiB'], mr);
     } finally {
-      if (prev !== null) { setCurrentDeviceResource(prev); }
+      if (prev != null) { setCurrentDeviceResource(prev); }
     }
   });
 });

--- a/modules/rmm/test/memory_resource/per-device-resource-tests.ts
+++ b/modules/rmm/test/memory_resource/per-device-resource-tests.ts
@@ -35,7 +35,7 @@ describe.each(memoryResourceTestConfigs)(`%s`, (_, {createMemoryResource}) => {
       expect(getPerDeviceResource(device.id)).toBe(mr);
       new DeviceBuffer(sizes['2_MiB'], mr);
     } finally {
-      if (prev !== null) { setPerDeviceResource(device.id, prev); }
+      if (prev != null) { setPerDeviceResource(device.id, prev); }
     }
   });
 });


### PR DESCRIPTION
A strict check for null was causing an undefined value to be
passed into a function that could not handle an undefined value.

------
This change is trivial and does not completely fix the tests that Paul and I were debugging. But I wanted to get a PR submitted and approved so I have the process down.