### PR TITLE
[FIX] Change df `concat` result type to `never`

### DIFF
--- a/modules/cudf/src/dataframe/concat.ts
+++ b/modules/cudf/src/dataframe/concat.ts
@@ -107,7 +107,13 @@ export function concat<TFirst extends DataFrame, TRest extends DataFrame[]>(firs
 
   type TResultTypeMap = ConcatTypeMap<TFirst, TRest>;
 
-  return new DataFrame(names.reduce(
-    (map, name, index) => ({...map, [name]: Series.new(concatenatedTable.getColumnByIndex(index))}),
-    {} as SeriesMap<{[P in keyof TResultTypeMap]: TResultTypeMap[P]}>));
+  // clang-format off
+  return new DataFrame(
+    names.reduce((map, name, index) =>
+    ({...map, [name]: Series.new(concatenatedTable.getColumnByIndex(index))}),
+    {} as SeriesMap<{[P in keyof TResultTypeMap]: TResultTypeMap[P]}>)
+  ) as TResultTypeMap[keyof TResultTypeMap] extends never
+    ? never
+    : DataFrame<{[P in keyof TResultTypeMap]: TResultTypeMap[P]}>;
+  // clang-format on
 }

--- a/modules/cudf/test/dataframe/concat-tests.ts
+++ b/modules/cudf/test/dataframe/concat-tests.ts
@@ -122,7 +122,7 @@ describe('dataframe.concat', () => {
       // For now, we'll just verify that concat returns a DataFrame<{ a: never }>
       verifyConcatResultType(result);
 
-      function verifyConcatResultType(_: DataFrame<{a: never}>) { return _; }
+      function verifyConcatResultType(_: never) { return _; }
     }).toThrow();
   });
 


### PR DESCRIPTION
This is how it previously used to return `never`

```ts
const result = df1.concat(df2);
// const result: DataFrame<{
//     a: never;
// }>

// IDE now autocomplete and allows calling of base level df methods
result.isNaN(); // no compiler error
```

```ts
const result = df1.concat(df2);
// const result: never

result.isNaN(); // compiler error since this entire obj is null
```

