### PR TITLE
Add DataFrame.fromArrow

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -46,7 +46,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `fillna`             |  ✅ (`replaceNulls`)  |
 | `floor`              |          ✅           |
 | `floordiv`           |          ✅           |
-| `from_arrow`         |                       |
+| `from_arrow`         |          ✅           |
 | `from_categorical`   |                       |
 | `from_masked_array`  |                       |
 | `from_pandas`        |                       |

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {MemoryResource} from '@rapidsai/rmm';
+import {Memory} from '@nvidia/cuda';
+import {DeviceBuffer, MemoryResource} from '@rapidsai/rmm';
 import * as arrow from 'apache-arrow';
 import {compareTypes} from 'apache-arrow/visitor/typecomparator';
 import {Readable} from 'stream';
@@ -101,6 +102,18 @@ export class DataFrame<T extends TypeMap = any> {
     return new DataFrame(new ColumnAccessor(
       names.reduce((map, name, i) => ({...map, [name]: table.getColumnByIndex(i)}),
                    {} as ColumnsMap<{[P in keyof T]: CSVToCUDFType<T[P]>}>)));
+  }
+
+  /**
+   * Reads a an arrow IPC table into a DataFrame.
+   *
+   * @param memory A buffer holding Arrow table
+   * @return The Arrow data as a DataFrame
+   */
+  public static fromArrow(memory: Memory|DeviceBuffer) {
+    const {names, table} = Table.fromArrow(memory);
+    return new DataFrame(new ColumnAccessor(
+      names.reduce((map, name, i) => ({...map, [name]: table.getColumnByIndex(i)}), {})));
   }
 
   private _accessor: ColumnAccessor<T>;

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -110,10 +110,10 @@ export class DataFrame<T extends TypeMap = any> {
    * @param memory A buffer holding Arrow table
    * @return The Arrow data as a DataFrame
    */
-  public static fromArrow(memory: Memory|DeviceBuffer) {
+  public static fromArrow<T extends TypeMap>(memory: Memory|DeviceBuffer): DataFrame<T> {
     const {names, table} = Table.fromArrow(memory);
-    return new DataFrame(new ColumnAccessor(
-      names.reduce((map, name, i) => ({...map, [name]: table.getColumnByIndex(i)}), {})));
+    return new DataFrame(new ColumnAccessor(names.reduce(
+      (map, name, i) => ({...map, [name]: table.getColumnByIndex(i)}), {} as ColumnsMap<T>)));
   }
 
   private _accessor: ColumnAccessor<T>;

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -105,7 +105,7 @@ export class DataFrame<T extends TypeMap = any> {
   }
 
   /**
-   * Reads a an arrow IPC table into a DataFrame.
+   * Adapts an Arrow Table in IPC format into a DataFrame.
    *
    * @param memory A buffer holding Arrow table
    * @return The Arrow data as a DataFrame

--- a/modules/cudf/src/node_cudf/table.hpp
+++ b/modules/cudf/src/node_cudf/table.hpp
@@ -236,6 +236,8 @@ struct Table : public EnvLocalObjectWrap<Table> {
   static Napi::Value read_csv(Napi::CallbackInfo const& info);
   void write_csv(Napi::CallbackInfo const& info);
 
+  static Napi::Value from_arrow(Napi::CallbackInfo const& info);
+
   Napi::Value to_arrow(Napi::CallbackInfo const& info);
   Napi::Value order_by(Napi::CallbackInfo const& info);
 };

--- a/modules/cudf/src/table.cpp
+++ b/modules/cudf/src/table.cpp
@@ -43,6 +43,7 @@ Napi::Function Table::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Table::order_by>("orderBy"),
                        StaticMethod<&Table::read_csv>("readCSV"),
                        InstanceMethod<&Table::write_csv>("writeCSV"),
+                       StaticMethod<&Table::from_arrow>("fromArrow"),
                        InstanceMethod<&Table::drop_nans>("dropNans"),
                        InstanceMethod<&Table::drop_nulls>("dropNulls"),
                        InstanceMethod<&Table::drop_duplicates>("dropDuplicates"),

--- a/modules/cudf/src/table.ts
+++ b/modules/cudf/src/table.ts
@@ -48,7 +48,7 @@ interface TableConstructor {
     {names: (keyof T)[], table: Table};
 
   /**
-   * Reads a an arrow IPC table into a set of columns.
+   * Adapts an arrow Table in IPC format into a set of columns.
    *
    * @param memory A buffer holding Arrow table
    * @return The Arrow data as a Table and a list of column names.

--- a/modules/cudf/src/table.ts
+++ b/modules/cudf/src/table.ts
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {MemoryResource} from '@rapidsai/rmm';
+import {Memory} from '@nvidia/cuda';
+import {DeviceBuffer, MemoryResource} from '@rapidsai/rmm';
+
 import CUDF from './addon';
 import {Column} from './column';
 import {Scalar} from './scalar';
@@ -44,6 +46,14 @@ interface TableConstructor {
    */
   readCSV<T extends CSVTypeMap = any>(options: ReadCSVOptions<T>):
     {names: (keyof T)[], table: Table};
+
+  /**
+   * Reads a an arrow IPC table into a set of columns.
+   *
+   * @param memory A buffer holding Arrow table
+   * @return The Arrow data as a Table and a list of column names.
+   */
+  fromArrow(memory: Memory|DeviceBuffer): {names: string[], table: Table};
 
   /**
    * Returns tables concatenated to each other.

--- a/modules/cudf/test/dataframe/arrow-tests.ts
+++ b/modules/cudf/test/dataframe/arrow-tests.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2020, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ChildProcessByStdio, spawn} from 'child_process';
+import {Readable, Writable} from 'stream';
+
+jest.setTimeout(60 * 1000);
+
+test(`fromArrow works between subprocesses`, async () => {
+  let src: ChildProcessByStdio<Writable, Readable, null>|undefined;
+  let dst: ChildProcessByStdio<Writable, Readable, null>|undefined;
+  try {
+    src          = spawnIPCSourceSubprocess();
+    const handle = await readChildProcessOutput(src);
+    if (handle) {
+      dst        = spawnIPCTargetSubprocess(JSON.parse(handle));
+      const data = await readChildProcessOutput(dst);
+      if (data) {
+        expect(JSON.parse(data))
+          .toStrictEqual(
+            {names: ['floats', 'ints'], a: [1.1, 2.2, 0, -3.3, -4.4], b: [1, 2, 0, -3, -4]});
+      } else {
+        throw new Error(`Invalid data from target child process: ${JSON.stringify(data)}`);
+      }
+    } else {
+      throw new Error(`Invalid IPC handle from source child process: ${JSON.stringify(handle)}`);
+    }
+  } finally {
+    dst && !dst.killed && dst.kill();
+    src && !src.killed && src.kill();
+  }
+});
+
+async function readChildProcessOutput(proc: ChildProcessByStdio<Writable, Readable, null>) {
+  const {stdout} = proc;
+  return (async () => {
+    for await (const chunk of stdout) {
+      if (chunk) {
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        return '' + chunk;
+      }
+    }
+    return '';
+  })();
+}
+
+function spawnIPCSourceSubprocess() {
+  return spawn('node',
+               [
+                 `-e`,
+                 `
+const { Table, FloatVector, IntVector } = require('apache-arrow');
+const { Uint8Buffer } = require('@nvidia/cuda');
+const table = Table.new(
+  [
+    FloatVector.from(new Float64Array([1.1, 2.2, 0, -3.3, -4.4])),
+    IntVector.from(new Int32Array([1, 2, 0, -3, -4]))
+  ],
+  ['floats', 'ints']
+);
+const serialized_table = table.serialize();  // Uint8Array
+const device_buffer = new Uint8Buffer(serialized_table.length);
+device_buffer.copyFrom(serialized_table);
+const handle = device_buffer.getIpcHandle();
+
+process.stdout.write(JSON.stringify(handle));
+process.on("exit", () => handle.close());
+setInterval(() => { }, 60 * 1000);
+`
+               ],
+               {stdio: ['pipe', 'pipe', 'inherit']});
+}
+
+function spawnIPCTargetSubprocess({handle}: {handle: Array<number>}) {
+  return spawn('node',
+               [
+                 '-e',
+                 `
+const { IpcMemory } = require("@nvidia/cuda");
+const { DataFrame } = require(".");
+const dmem = new IpcMemory([${handle.toString()}]);
+const df = DataFrame.fromArrow(dmem);
+
+process.stdout.write(JSON.stringify({ names: [...df.names], a: [...df.get('floats')], b: [...df.get('ints')] }));
+`
+               ],
+               {stdio: ['pipe', 'pipe', 'inherit']});
+}


### PR DESCRIPTION
Add a static `DataFrame.fromArrow` method that can adapt Arrow tables stored in-memory in Arrow IPC format.
 
This is still WIP but early comments welcome. Some notes:

* As implemented, this requires a copy. Plan to to push improvements upstream to `cudf::from_arrow` to allow it to perform zero-copy when feasible (e.g. ipc buffers)
* Tests are a bit thin. Open to suggestions to improve coverage parsimoniously 
* ~~Still need to add an input type to `fromArrow` (similar to `readCSV`) so that full types can be deduced~~
