### PR TITLE
[FIX] Reduce amount of memory RMM tests allocate

### DIFF
--- a/modules/rmm/test/memory_resource/utils.ts
+++ b/modules/rmm/test/memory_resource/utils.ts
@@ -91,7 +91,7 @@ export const memoryResourceTestConfigs = [
       supportsStreams: true,
       supportsGetMemInfo: false,
       createMemoryResource: () => new BinningMemoryResource(
-        new CudaMemoryResource(), Math.log2(sizes['1_MiB']), Math.log2(sizes['4_MiB'])),
+        new CudaMemoryResource(), Math.log2(sizes['1_MiB']), Math.log2(sizes['1_MiB'])),
     }
   ],
   [


### PR DESCRIPTION
cc @trxcllnt 

Spoke with Paul about this, RMM was consuming all memory and breaking the ability to run the tests on a lower spec machine.