### PR TITLE
Fix exclusive_scan test crash

### DIFF
--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -307,7 +307,7 @@ cudf::column_view Column::view() const {
     child_views.emplace_back(*Column::Unwrap(child));
   }
 
-  return cudf::column_view{type, size_, *data, *mask, null_count_, offset_, child_views};
+  return cudf::column_view(type, size_, *data, *mask, null_count_, offset_, child_views);
 }
 
 cudf::mutable_column_view Column::mutable_view() {


### PR DESCRIPTION
This fix (from @trxcllnt) resolves hard crashes that can show up sporadically in `test/series/list-tests.ts`

>what():  exclusive_scan failed to synchronize: cudaErrorIllegalAddress: an illegal memory access was encountered

Using the initializer list construction could result in the column view being improperly initialized. 
