### PR TITLE
Add `Series` copy binding

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -25,7 +25,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `atan`               |          ✅           |
 | `ceil`               |          ✅           |
 | `clip`               |                       |
-| `copy`               |                       |
+| `copy`               |          ✅           |
 | `corr`               |                       |
 | `cos`                |          ✅           |
 | `count`              | ✅ (`countNonNulls`)  |
@@ -155,7 +155,7 @@ The tables below show the bindings that have been implemented in `node-rapids`.
 | `as_mask`            |                       |                       |                       |
 | `astype`             |      ✅ (`cast`)      |      ✅ (`cast`)      |      ✅ (`cast`)      |
 | `clip`               |                       |                       |                       |
-| `copy`               |                       |                       |                       |
+| `copy`               |          ✅           |          ✅           |          ✅           |
 | `count`              | ✅ (`countNonNulls`)  | ✅ (`countNonNulls`)  | ✅ (`countNonNulls`)  |
 | `describe`           |                       |                       |                       |
 | `diff`               |                       |                       |                       |

--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -41,6 +41,7 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Column::set_null_count>("setNullCount"),
                        // column/copying.cpp
                        InstanceMethod<&Column::gather>("gather"),
+                       InstanceMethod<&Column::copy>("copy"),
                        // column/filling.cpp
                        InstanceMethod<&Column::fill>("fill"),
                        InstanceMethod<&Column::fill_in_place>("fillInPlace"),

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -123,6 +123,12 @@ export interface Column<T extends DataType = any> {
   gather(selection: Column<IndexType|Bool8>): Column<T>;
 
   /**
+   * Return a copy of a Column
+   *
+   */
+  copy(memoryResource?: MemoryResource): Column<T>;
+
+  /**
    * Return a child at the specified index to host memory
    *
    * @param index

--- a/modules/cudf/src/column/copying.cpp
+++ b/modules/cudf/src/column/copying.cpp
@@ -30,4 +30,10 @@ Column::wrapper_t Column::gather(Column const& gather_map,
       cudf::gather(cudf::table_view{{*this}}, gather_map, bounds_policy, mr)->release()[0]));
 }
 
+Napi::Value Column::copy(Napi::CallbackInfo const& info) {
+  CallbackArgs args{info};
+  return Column::New(
+    args.Env(), std::make_unique<cudf::column>(this->view(), rmm::cuda_stream_default, args[0]));
+}
+
 }  // namespace nv

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -653,8 +653,8 @@ struct Column : public EnvLocalObjectWrap<Column> {
     cudf::out_of_bounds_policy bounds_policy = cudf::out_of_bounds_policy::DONT_CHECK,
     rmm::mr::device_memory_resource* mr      = rmm::mr::get_current_device_resource()) const;
 
-  Column::wrapper_t copy(
-    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+  // Column::wrapper_t copy(
+  //   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
   // column/filling.cpp
   Column::wrapper_t fill(

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -653,6 +653,10 @@ struct Column : public EnvLocalObjectWrap<Column> {
     cudf::out_of_bounds_policy bounds_policy = cudf::out_of_bounds_policy::DONT_CHECK,
     rmm::mr::device_memory_resource* mr      = rmm::mr::get_current_device_resource()) const;
 
+  // NOT IMPLEMENTED
+  Column::wrapper_t copy(
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
   // column/filling.cpp
   Column::wrapper_t fill(
     cudf::size_type begin,
@@ -747,6 +751,7 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Napi::Value num_children(Napi::CallbackInfo const& info);
 
   Napi::Value gather(Napi::CallbackInfo const& info);
+  Napi::Value copy(Napi::CallbackInfo const& info);
 
   Napi::Value get_child(Napi::CallbackInfo const& info);
 

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -653,7 +653,6 @@ struct Column : public EnvLocalObjectWrap<Column> {
     cudf::out_of_bounds_policy bounds_policy = cudf::out_of_bounds_policy::DONT_CHECK,
     rmm::mr::device_memory_resource* mr      = rmm::mr::get_current_device_resource()) const;
 
-  // NOT IMPLEMENTED
   Column::wrapper_t copy(
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -653,9 +653,6 @@ struct Column : public EnvLocalObjectWrap<Column> {
     cudf::out_of_bounds_policy bounds_policy = cudf::out_of_bounds_policy::DONT_CHECK,
     rmm::mr::device_memory_resource* mr      = rmm::mr::get_current_device_resource()) const;
 
-  // Column::wrapper_t copy(
-  //   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
-
   // column/filling.cpp
   Column::wrapper_t fill(
     cudf::size_type begin,

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -653,7 +653,6 @@ export class AbstractSeries<T extends DataType = any> {
   /**
    * Return a copy of this Series.
    *
-   *
    * @example
    * ```typescript
    * import {Series} from '@rapidsai/cudf';
@@ -664,10 +663,8 @@ export class AbstractSeries<T extends DataType = any> {
    * ```
    */
   copy(memoryResource?: MemoryResource): Series<T> {
-    // const lhs = <Column>(this._col);
     return Series.new(this._col.copy(memoryResource));
   }
-  // this.__construct(this._col.copy()); }
 
   /**
    * Returns the n largest element(s).

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -651,6 +651,25 @@ export class AbstractSeries<T extends DataType = any> {
   }
 
   /**
+   * Return a copy of this Series.
+   *
+   *
+   * @example
+   * ```typescript
+   * import {Series} from '@rapidsai/cudf';
+   *
+   * const a = Series.new(["foo", "bar", "test"]);
+   *
+   * a.copy() // StringSeries ["foo", "bar", "test"]
+   * ```
+   */
+  copy(memoryResource?: MemoryResource): Series<T> {
+    // const lhs = <Column>(this._col);
+    return Series.new(this._col.copy(memoryResource));
+  }
+  // this.__construct(this._col.copy()); }
+
+  /**
    * Returns the n largest element(s).
    *
    * @param n The number of values to retrieve.
@@ -749,8 +768,8 @@ export class AbstractSeries<T extends DataType = any> {
    * @param value A column of values to be scattered in to this Series
    * @param indices A column of integral indices that indicate the rows in the this Series to be
    *   replaced by `value`.
-   * @param check_bounds Optionally perform bounds checking on the indices and throw an error if any
-   *   of its values are out of bounds (default: false).
+   * @param check_bounds Optionally perform bounds checking on the indices and throw an error if
+   *   any of its values are out of bounds (default: false).
    * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
    *
    * @example
@@ -775,8 +794,8 @@ export class AbstractSeries<T extends DataType = any> {
    * @param value A value to be scattered in to this Series
    * @param indices A column of integral indices that indicate the rows in the this Series to be
    *   replaced by `value`.
-   * @param check_bounds Optionally perform bounds checking on the indices and throw an error if any
-   *   of its values are out of bounds (default: false).
+   * @param check_bounds Optionally perform bounds checking on the indices and throw an error if
+   *   any of its values are out of bounds (default: false).
    * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
    *
    * @example
@@ -1105,7 +1124,8 @@ export class AbstractSeries<T extends DataType = any> {
    *
    * @param keep Determines whether or not to keep the duplicate items.
    * @param nullsEqual Determines whether nulls are handled as equal values.
-   * @param nullsFirst Determines whether null values are inserted before or after non-null values.
+   * @param nullsFirst Determines whether null values are inserted before or after non-null
+   *   values.
    * @param memoryResource Memory resource used to allocate the result Column's device memory.
    * @returns series without duplicate values
    *

--- a/modules/cudf/test/cudf-series-test.ts
+++ b/modules/cudf/test/cudf-series-test.ts
@@ -189,6 +189,22 @@ test('NumericSeries.concat up-casts to common dtype', () => {
   expect([...result]).toEqual([...col, ...colToConcat]);
 });
 
+test('Series.copy fixed width', () => {
+  const col = Series.new({type: new Int32, data: new Int32Buffer([1, 2, 3, 4, 5])});
+
+  const result = col.copy();
+
+  expect([...result]).toEqual([...col]);
+});
+
+test('Series.copy String', () => {
+  const col = Series.new(['foo', 'bar', 'test', null]);
+
+  const result = col.copy();
+
+  expect([...result]).toEqual([...col]);
+});
+
 test('Series.gather', () => {
   const col = Series.new({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])});
 

--- a/modules/cudf/test/series/list-tests.ts
+++ b/modules/cudf/test/series/list-tests.ts
@@ -121,6 +121,22 @@ describe('ListSeries', () => {
     const result = col.concat(colToConcat);
     expect([...result]).toEqual([...col, ...colToConcat]);
   });
+
+  test('Can copy Lists', () => {
+    const vec = listsOfInt32s([[1, 2, 3], [4, 5, 6]]);
+    const col = Series.new(vec);
+
+    const result = col.copy();
+    expect([...result]).toEqual([...col]);
+  });
+
+  test('Can copy List of Lists', () => {
+    const vec = listsOfListsOfInt32s([[[0, 1, 2]], [[3, 4, 5], [7, 8, 9]]]);
+    const col = Series.new(vec);
+
+    const result = col.copy();
+    expect([...result]).toEqual([...col]);
+  });
 });
 
 type ListOfInt32 = arrow.List<arrow.Int32>;

--- a/modules/cudf/test/series/string-tests.ts
+++ b/modules/cudf/test/series/string-tests.ts
@@ -43,6 +43,16 @@ describe('StringSeries', () => {
   });
 });
 
+describe('StringSeries', () => {
+  test('Can copy', () => {
+    const col = StringSeries.new(['foo', 'bar']);
+
+    const result = col.copy();
+
+    expect([...result]).toEqual([...col]);
+  });
+});
+
 describe.each([['foo'], [/foo/], [/foo/ig]])('Series regex search (pattern=%p)', (pattern) => {
   test('containsRe', () => {
     const expected = [true, true, true, true, true, false, false, true, true];

--- a/modules/cudf/test/series/struct-tests.ts
+++ b/modules/cudf/test/series/struct-tests.ts
@@ -98,6 +98,17 @@ describe('StructSeries', () => {
     const result = vec.concat(vecToConcat);
     expect([...result]).toEqual([...vec, ...vecToConcat]);
   });
+
+  test('Can copy', () => {
+    const vec = structsOfStructsOfInt32s([
+      {point: {x: 0, y: 3}},
+      {point: {x: 1, y: 4}},
+      {point: {x: 2, y: 5}},
+    ]);
+
+    const result = vec.concat();
+    expect([...result]).toEqual([...vec]);
+  });
 });
 
 type StructOfInt32   = arrow.Struct<{x: arrow.Int32, y: arrow.Int32}>;


### PR DESCRIPTION
Add binding for a deep copy of a Column

---------
Backed by a deep-copy constructor in cudf::column, so functionally very little to go wrong.
All cudf tests pass.