### PR TITLE
[FEA] Remove esm, add npm bin files to all demos

### DIFF
--- a/dockerfiles/runtime.Dockerfile
+++ b/dockerfiles/runtime.Dockerfile
@@ -80,8 +80,6 @@ USER node
 
 COPY --from=build --chown=node:node /home/node/node_modules /home/node/node_modules
 
-ENV NODE_PATH=/home/node/node_modules
-
 WORKDIR /home/node
 
-CMD ["node", "-r", "esm"]
+CMD ["node"]

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -41,7 +41,6 @@
     "cmake-js": "6.0.0",
     "dotenv": "8.2.0",
     "jest": "26.5.3",
-    "esm": "3.2.25",
     "node-addon-api": "3.2.1",
     "rimraf": "3.0.0",
     "segfault-handler": "1.3.0",

--- a/modules/demo/client-server/index.js
+++ b/modules/demo/client-server/index.js
@@ -14,24 +14,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-require('segfault-handler').registerHandler('./crash.log');
+const Path = require('path');
 
-require('@babel/register')({
-  cache: false,
-  babelrc: false,
-  cwd: __dirname,
-  presets: [
-    ["@babel/preset-env", { "targets": { "node": "current" } }],
-    ['@babel/preset-react', { "useBuiltIns": true }]
-  ]
-});
+require('segfault-handler').registerHandler('./crash.log');
 
 // Change cwd to the example dir so relative file paths are resolved
 process.chdir(__dirname);
 
-const { createReactWindow } = require('@nvidia/glfw');
-module.exports = createReactWindow(`${__dirname}/app.js`, true);
+const next = require.resolve('next/dist/bin/next');
 
-if (require.main === module) {
-  module.exports.open({ transparent: false });
-}
+require('fs').stat(Path.join(__dirname, '.next'), (err, stats) => {
+
+  const { spawnSync } = require('child_process');
+
+  const env = {
+    NEXT_TELEMETRY_DISABLED: 1, // disable https://nextjs.org/telemetry
+    ...process.env,
+  };
+
+  if (err || !stats || !stats.isDirectory()) {
+    spawnSync(
+      process.execPath, [next, 'build'],
+      { env, cwd: __dirname, stdio: 'inherit' });
+  }
+
+  spawnSync(
+    process.execPath, [next, 'start'],
+    { env, cwd: __dirname, stdio: 'inherit' });
+});

--- a/modules/demo/client-server/package.json
+++ b/modules/demo/client-server/package.json
@@ -6,6 +6,7 @@
   "maintainers": [
     "Ajay Thorve(athorve@nvidia.com)"
   ],
+  "bin": "index.js",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/modules/demo/deck/3d-heatmap/index.js
+++ b/modules/demo/deck/3d-heatmap/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/3d-heatmap/package.json
+++ b/modules/demo/deck/3d-heatmap/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/3d-heatmap/package.json
+++ b/modules/demo/deck/3d-heatmap/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/aggregation-layers": "8.4.17",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/3d-tiles/index.js
+++ b/modules/demo/deck/3d-tiles/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/3d-tiles/package.json
+++ b/modules/demo/deck/3d-tiles/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/geo-layers": "8.4.17",
     "@deck.gl/react": "8.4.17",
     "@loaders.gl/core": "2.3.13",

--- a/modules/demo/deck/3d-tiles/package.json
+++ b/modules/demo/deck/3d-tiles/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/ShanghaiData/index.js
+++ b/modules/demo/deck/ShanghaiData/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/ShanghaiData/package.json
+++ b/modules/demo/deck/ShanghaiData/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/ShanghaiData/package.json
+++ b/modules/demo/deck/ShanghaiData/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/arc/index.js
+++ b/modules/demo/deck/arc/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/arc/package.json
+++ b/modules/demo/deck/arc/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/arc/package.json
+++ b/modules/demo/deck/arc/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/bezier/index.js
+++ b/modules/demo/deck/bezier/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/bezier/package.json
+++ b/modules/demo/deck/bezier/package.json
@@ -8,9 +8,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/bezier/package.json
+++ b/modules/demo/deck/bezier/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/brushing/index.js
+++ b/modules/demo/deck/brushing/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/brushing/package.json
+++ b/modules/demo/deck/brushing/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/brushing/package.json
+++ b/modules/demo/deck/brushing/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/extensions": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/data-filter/index.js
+++ b/modules/demo/deck/data-filter/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/data-filter/package.json
+++ b/modules/demo/deck/data-filter/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/data-filter/package.json
+++ b/modules/demo/deck/data-filter/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/extensions": "8.4.17",
     "@deck.gl/layers": "8.4.17",

--- a/modules/demo/deck/esri/index.js
+++ b/modules/demo/deck/esri/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/esri/package.json
+++ b/modules/demo/deck/esri/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@rapidsai/demo-deck-pure-js-esri-arcgis",
   "version": "0.0.0",
-  "license": "MIT",
+  "main": "index.js",
+  "license": "Apache-2.0",
+  "author": "NVIDIA, Inc. (https://nvidia.com/)",
+  "maintainers": [
+    "Paul Taylor <paul.e.taylor@me.com>"
+  ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/esri/package.json
+++ b/modules/demo/deck/esri/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/arcgis": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@esri/react-arcgis": "4.0.0",

--- a/modules/demo/deck/geojson/index.js
+++ b/modules/demo/deck/geojson/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/geojson/package.json
+++ b/modules/demo/deck/geojson/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/geojson/package.json
+++ b/modules/demo/deck/geojson/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/h3-grid/index.js
+++ b/modules/demo/deck/h3-grid/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/h3-grid/package.json
+++ b/modules/demo/deck/h3-grid/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/react": "8.4.17",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",

--- a/modules/demo/deck/h3-grid/package.json
+++ b/modules/demo/deck/h3-grid/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/heatmap/index.js
+++ b/modules/demo/deck/heatmap/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/heatmap/package.json
+++ b/modules/demo/deck/heatmap/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/heatmap/package.json
+++ b/modules/demo/deck/heatmap/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/aggregation-layers": "8.4.17",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/highway/index.js
+++ b/modules/demo/deck/highway/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/highway/package.json
+++ b/modules/demo/deck/highway/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/highway/package.json
+++ b/modules/demo/deck/highway/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/icon/index.js
+++ b/modules/demo/deck/icon/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/icon/package.json
+++ b/modules/demo/deck/icon/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/icon/package.json
+++ b/modules/demo/deck/icon/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/image-tile/index.js
+++ b/modules/demo/deck/image-tile/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/image-tile/package.json
+++ b/modules/demo/deck/image-tile/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/image-tile/package.json
+++ b/modules/demo/deck/image-tile/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/geo-layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/interleaved-buffer/index.js
+++ b/modules/demo/deck/interleaved-buffer/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/interleaved-buffer/package.json
+++ b/modules/demo/deck/interleaved-buffer/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/interleaved-buffer/package.json
+++ b/modules/demo/deck/interleaved-buffer/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@luma.gl/core": "8.4.5",

--- a/modules/demo/deck/line/index.js
+++ b/modules/demo/deck/line/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/line/package.json
+++ b/modules/demo/deck/line/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/line/package.json
+++ b/modules/demo/deck/line/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/map-tile/index.js
+++ b/modules/demo/deck/map-tile/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/map-tile/package.json
+++ b/modules/demo/deck/map-tile/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/geo-layers": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/map-tile/package.json
+++ b/modules/demo/deck/map-tile/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/mesh/index.js
+++ b/modules/demo/deck/mesh/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/mesh/package.json
+++ b/modules/demo/deck/mesh/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/react": "8.4.17",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",

--- a/modules/demo/deck/mesh/package.json
+++ b/modules/demo/deck/mesh/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/playground/index.js
+++ b/modules/demo/deck/playground/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/playground/package.json
+++ b/modules/demo/deck/playground/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/playground/package.json
+++ b/modules/demo/deck/playground/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/aggregation-layers": "8.4.17",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/json": "8.4.17",

--- a/modules/demo/deck/plot/index.js
+++ b/modules/demo/deck/plot/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/plot/package.json
+++ b/modules/demo/deck/plot/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/plot/package.json
+++ b/modules/demo/deck/plot/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/react": "8.4.17",
     "@nvidia/glfw": "0.0.1",

--- a/modules/demo/deck/point-cloud/index.js
+++ b/modules/demo/deck/point-cloud/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/point-cloud/package.json
+++ b/modules/demo/deck/point-cloud/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/react": "8.4.17",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",

--- a/modules/demo/deck/point-cloud/package.json
+++ b/modules/demo/deck/point-cloud/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/scatterplot/index.js
+++ b/modules/demo/deck/scatterplot/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/scatterplot/package.json
+++ b/modules/demo/deck/scatterplot/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/scatterplot/package.json
+++ b/modules/demo/deck/scatterplot/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/scenegraph-layer/index.js
+++ b/modules/demo/deck/scenegraph-layer/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/scenegraph-layer/package.json
+++ b/modules/demo/deck/scenegraph-layer/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/scenegraph-layer/package.json
+++ b/modules/demo/deck/scenegraph-layer/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/react": "8.4.17",
     "@deck.gl/mesh-layers": "8.4.17",
     "@loaders.gl/gltf": "2.3.13",

--- a/modules/demo/deck/screen-grid/index.js
+++ b/modules/demo/deck/screen-grid/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/screen-grid/package.json
+++ b/modules/demo/deck/screen-grid/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/screen-grid/package.json
+++ b/modules/demo/deck/screen-grid/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/aggregation-layers": "8.4.17",
     "@luma.gl/core": "8.4.5",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/tagmap/index.js
+++ b/modules/demo/deck/tagmap/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/tagmap/package.json
+++ b/modules/demo/deck/tagmap/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/tagmap/package.json
+++ b/modules/demo/deck/tagmap/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/text-layer/index.js
+++ b/modules/demo/deck/text-layer/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/text-layer/package.json
+++ b/modules/demo/deck/text-layer/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/text-layer/package.json
+++ b/modules/demo/deck/text-layer/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/deck/trips/index.js
+++ b/modules/demo/deck/trips/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/trips/package.json
+++ b/modules/demo/deck/trips/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/trips/package.json
+++ b/modules/demo/deck/trips/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/react": "8.4.17",
     "@deck.gl/layers": "8.4.17",

--- a/modules/demo/deck/worldmap/index.js
+++ b/modules/demo/deck/worldmap/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/deck/worldmap/package.json
+++ b/modules/demo/deck/worldmap/package.json
@@ -7,9 +7,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/worldmap/package.json
+++ b/modules/demo/deck/worldmap/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@deck.gl/react": "8.4.17",

--- a/modules/demo/graph/index.js
+++ b/modules/demo/graph/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/graph/package.json
+++ b/modules/demo/graph/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/react": "8.4.17",
     "@luma.gl/core": "8.4.5",

--- a/modules/demo/graph/package.json
+++ b/modules/demo/graph/package.json
@@ -8,9 +8,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -dr node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -dr node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/graph/src/index.js
+++ b/modules/demo/graph/src/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/ipc/graph/index.js
+++ b/modules/demo/ipc/graph/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/ipc/graph/package.json
+++ b/modules/demo/ipc/graph/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/react": "8.4.17",
     "@luma.gl/core": "8.4.5",

--- a/modules/demo/ipc/graph/package.json
+++ b/modules/demo/ipc/graph/package.json
@@ -8,8 +8,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node ./index.js"
+    "start": "node ./index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/ipc/graph/src/index.js
+++ b/modules/demo/ipc/graph/src/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/ipc/umap/index.js
+++ b/modules/demo/ipc/umap/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/ipc/umap/package.json
+++ b/modules/demo/ipc/umap/package.json
@@ -8,8 +8,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node ./index.js"
+    "start": "node ./index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/ipc/umap/package.json
+++ b/modules/demo/ipc/umap/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/layers": "8.4.17",
     "@luma.gl/constants": "8.4.5",

--- a/modules/demo/luma/index.js
+++ b/modules/demo/luma/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/luma/package.json
+++ b/modules/demo/luma/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@nvidia/glfw": "0.0.1",
     "segfault-handler": "1.3.0"
   },

--- a/modules/demo/luma/package.json
+++ b/modules/demo/luma/package.json
@@ -8,6 +8,11 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
+  },
   "dependencies": {
     "@babel/core": "7.14.6",
     "@babel/preset-env": "7.14.7",

--- a/modules/demo/spatial/data.js
+++ b/modules/demo/spatial/data.js
@@ -27,7 +27,7 @@ if (require.main === module) {
 
 async function loadSpatialDataset() {
 
-  const points = (await loadFiles()).reduce((points, file) => {
+  const points = (await loadFiles(1)).reduce((points, file) => {
     return points ? points.concat(reshape(file)) : reshape(file);
   }, null).castAll(new Float32);
 
@@ -53,7 +53,7 @@ async function loadFiles(numConcurrentRequests = 4) {
   return files;
 }
 
-function reshape({ buffer: file }) {
+function reshape(file) {
   const size = file.byteLength / 16;
   const shape = { type: new Int32, step: 4, size };
   const data = Series.new({ type: new Int32, data: file });
@@ -67,7 +67,7 @@ function loadFile(i) {
 
   const options = {
     method: `GET`,
-    path: `/spatial/2009${i < 10 ? '0' : ''}${i}.cny`,
+    path: `/spatial/2009${i < 10 ? '0' : ''}${i}.cny.gz`,
     hostname: `node-rapids-data.s3.us-west-2.amazonaws.com`,
     headers: {
       [`Accept`]: `application/octet-stream`,
@@ -83,6 +83,9 @@ function loadFile(i) {
 
       let body = new Uint8Array(res.headers['content-length'] | 0);
 
+      console.log('content-encoding:', encoding);
+      console.log('content-length:', body.byteLength);
+
       if (encoding.includes('gzip')) {
         res = res.pipe(require('zlib').createGunzip());
       } else if (encoding.includes('deflate')) {
@@ -93,10 +96,18 @@ function loadFile(i) {
 
       finished(
         res.on('data', (part) => {
+          if (body.buffer.byteLength < body.byteOffset + part.byteLength) {
+            const both = new Uint8Array(Math.max(
+              body.buffer.byteLength * 2,
+              body.buffer.byteLength + part.byteLength
+            ));
+            both.set(new Uint8Array(body.buffer, 0, body.byteOffset));
+            body = both.subarray(body.byteOffset);
+          }
           body.set(part);
           body = body.subarray(part.byteLength);
         })
-      ).then(() => resolve(body)).catch(reject);
+      ).then(() => resolve(new Uint8Array(body.buffer, 0, body.byteOffset))).catch(reject);
     });
 
     req.end();

--- a/modules/demo/spatial/data.js
+++ b/modules/demo/spatial/data.js
@@ -83,9 +83,6 @@ function loadFile(i) {
 
       let body = new Uint8Array(res.headers['content-length'] | 0);
 
-      console.log('content-encoding:', encoding);
-      console.log('content-length:', body.byteLength);
-
       if (encoding.includes('gzip')) {
         res = res.pipe(require('zlib').createGunzip());
       } else if (encoding.includes('deflate')) {

--- a/modules/demo/spatial/package.json
+++ b/modules/demo/spatial/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@deck.gl/core": "8.4.17",
     "@deck.gl/react": "8.4.17",
     "@luma.gl/core": "8.4.5",

--- a/modules/demo/spatial/package.json
+++ b/modules/demo/spatial/package.json
@@ -1,15 +1,17 @@
 {
   "private": true,
   "name":  "@rapidsai/demo-spatial",
+  "main": "index.js",
   "version": "0.0.0",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/tfjs/addition-rnn/index.js
+++ b/modules/demo/tfjs/addition-rnn/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/tfjs/addition-rnn/package.json
+++ b/modules/demo/tfjs/addition-rnn/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@nvidia/glfw": "0.0.1",
     "@tensorflow/tfjs": "2.8.6",
     "chalk": "4.1.0",

--- a/modules/demo/tfjs/addition-rnn/package.json
+++ b/modules/demo/tfjs/addition-rnn/package.json
@@ -8,6 +8,11 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
+  },
   "dependencies": {
     "@babel/core": "7.14.6",
     "@babel/preset-env": "7.14.7",

--- a/modules/demo/tfjs/webgl-tests/index.js
+++ b/modules/demo/tfjs/webgl-tests/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2021, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/tfjs/webgl-tests/package.json
+++ b/modules/demo/tfjs/webgl-tests/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "7.14.7",
     "@babel/preset-react": "7.14.5",
     "@babel/register": "7.14.5",
-    "esm": "3.2.25",
     "@nvidia/glfw": "0.0.1",
     "@tensorflow/tfjs": "2.8.6",
     "jasmine": "3.1.0",

--- a/modules/demo/tfjs/webgl-tests/package.json
+++ b/modules/demo/tfjs/webgl-tests/package.json
@@ -8,6 +8,11 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
+  },
   "dependencies": {
     "@babel/core": "7.14.6",
     "@babel/preset-env": "7.14.7",

--- a/modules/demo/xterm/index.js
+++ b/modules/demo/xterm/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/demo/xterm/package.json
+++ b/modules/demo/xterm/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@nvidia/glfw": "0.0.1",
-    "esm": "3.2.25",
     "segfault-handler": "1.3.0",
     "xterm": "4.3.0",
     "xterm-addon-webgl": "0.4.1"

--- a/modules/demo/xterm/package.json
+++ b/modules/demo/xterm/package.json
@@ -8,9 +8,10 @@
   "maintainers": [
     "Paul Taylor <paul.e.taylor@me.com>"
   ],
+  "bin": "index.js",
   "scripts": {
-    "start": "node -r esm index.js",
-    "watch": "find -type f | entr -c -d -r node -r esm index.js"
+    "start": "node index.js",
+    "watch": "find -type f | entr -c -d -r node index.js"
   },
   "dependencies": {
     "@nvidia/glfw": "0.0.1",

--- a/scripts/demo/linux.sh
+++ b/scripts/demo/linux.sh
@@ -55,8 +55,8 @@ if [[ "$DEMO" =~ "modules/demo/luma" ]]; then ARGS="${@:-01}";
 elif [[ "$DEMO" =~ "modules/demo/ipc/umap" ]]; then ARGS="${@:-tcp://0.0.0.0:6000}";
 fi
 
-if [[ "$DEMO" =~ "modules/demo/client-server" ]]; then 
+if [[ "$DEMO" =~ "modules/demo/client-server" ]]; then
     NODE_ENV=production exec npm --prefix="$DEMO" $ARGS start
 else
-    NODE_ENV=production exec node -r esm --trace-uncaught "$DEMO" $ARGS
+    NODE_ENV=production exec node --trace-uncaught "$DEMO" $ARGS
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -6403,11 +6403,6 @@ eslint@7.27.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@3.2.25:
-  version "3.2.25"
-  resolved "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
-
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3425,9 +3425,9 @@
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/underscore@*":
-  version "1.11.2"
-  resolved "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.2.tgz#9441e0f6402bbcb72dbee771582fa57c5a1dedd3"
-  integrity sha512-Ls2ylbo7++ITrWk2Yc3G/jijwSq5V3GT0tlgVXEl2kKYXY3ImrtmTCoE2uyTWFRI5owMBriloZFWbE1SXOsE7w==
+  version "1.11.3"
+  resolved "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.3.tgz#d6734f3741ce41b2630018c6b61c6745f6188c07"
+  integrity sha512-Fl1TX1dapfXyDqFg2ic9M+vlXRktcPJrc4PR7sRc7sdVrjavg/JHlbUXBt8qWWqhJrmSqg3RNAkAPRiOYw6Ahw==
 
 "@types/warning@^3.0.0":
   version "3.0.0"
@@ -3445,14 +3445,14 @@
   integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
 
 "@types/yargs-parser@*":
-  version "20.2.0"
-  resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
-  integrity sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==
+  version "20.2.1"
+  resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
+  integrity sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
 
 "@types/yargs@^15.0.0":
-  version "15.0.13"
-  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz#34f7fec8b389d7f3c1fd08026a5763e072d3c6dc"
-  integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
+  version "15.0.14"
+  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
+  integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
   dependencies:
     "@types/yargs-parser" "*"
 


### PR DESCRIPTION
* Removes `esm` dependency because `@babel/register` seems to do it all now
* Adds a `"bin"` entry to each demo so they can be launched like any other npm bin script

Now demos can be launched directly with `yarn demo-graph` or `npx demo-graph`.