### PR TITLE
[FIX] Run demos with esm so we can patch mjolnir.js again

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@types/node": "^15.0.0",
+    "esm": "3.2.25",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/modules/cudf/package.json
+++ b/modules/cudf/package.json
@@ -34,7 +34,7 @@
     "apache-arrow": "4.0.0"
   },
   "devDependencies": {
-    "ix": "4.4.0"
+    "ix": "4.4.1"
   },
   "files": [
     "LICENSE",

--- a/modules/demo/deck/3d-heatmap/package.json
+++ b/modules/demo/deck/3d-heatmap/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/3d-tiles/package.json
+++ b/modules/demo/deck/3d-tiles/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/ShanghaiData/package.json
+++ b/modules/demo/deck/ShanghaiData/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/arc/package.json
+++ b/modules/demo/deck/arc/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/bezier/package.json
+++ b/modules/demo/deck/bezier/package.json
@@ -10,8 +10,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/brushing/package.json
+++ b/modules/demo/deck/brushing/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/data-filter/package.json
+++ b/modules/demo/deck/data-filter/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/esri/package.json
+++ b/modules/demo/deck/esri/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/geojson/package.json
+++ b/modules/demo/deck/geojson/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/h3-grid/package.json
+++ b/modules/demo/deck/h3-grid/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/heatmap/package.json
+++ b/modules/demo/deck/heatmap/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/highway/package.json
+++ b/modules/demo/deck/highway/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/icon/package.json
+++ b/modules/demo/deck/icon/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/image-tile/package.json
+++ b/modules/demo/deck/image-tile/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/interleaved-buffer/package.json
+++ b/modules/demo/deck/interleaved-buffer/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/line/package.json
+++ b/modules/demo/deck/line/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/map-tile/package.json
+++ b/modules/demo/deck/map-tile/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/mesh/package.json
+++ b/modules/demo/deck/mesh/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/playground/package.json
+++ b/modules/demo/deck/playground/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/plot/package.json
+++ b/modules/demo/deck/plot/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/point-cloud/package.json
+++ b/modules/demo/deck/point-cloud/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/scatterplot/package.json
+++ b/modules/demo/deck/scatterplot/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/scenegraph-layer/package.json
+++ b/modules/demo/deck/scenegraph-layer/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/screen-grid/package.json
+++ b/modules/demo/deck/screen-grid/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/tagmap/package.json
+++ b/modules/demo/deck/tagmap/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/text-layer/package.json
+++ b/modules/demo/deck/text-layer/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/trips/package.json
+++ b/modules/demo/deck/trips/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/deck/worldmap/package.json
+++ b/modules/demo/deck/worldmap/package.json
@@ -9,8 +9,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/graph/package.json
+++ b/modules/demo/graph/package.json
@@ -10,8 +10,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -dr node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -dr node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",
@@ -26,7 +26,7 @@
     "@rapidsai/cudf": "0.0.1",
     "@rapidsai/cugraph": "0.0.1",
     "@rapidsai/deck.gl": "0.0.1",
-    "ix": "4.4.0",
+    "ix": "4.4.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "segfault-handler": "1.3.0"

--- a/modules/demo/ipc/graph/package.json
+++ b/modules/demo/ipc/graph/package.json
@@ -10,8 +10,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node ./index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",
@@ -26,7 +26,7 @@
     "@rapidsai/cudf": "0.0.1",
     "@rapidsai/cugraph": "0.0.1",
     "@rapidsai/deck.gl": "0.0.1",
-    "ix": "4.4.0",
+    "ix": "4.4.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "segfault-handler": "1.3.0",

--- a/modules/demo/ipc/umap/package.json
+++ b/modules/demo/ipc/umap/package.json
@@ -10,8 +10,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node ./index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/luma/package.json
+++ b/modules/demo/luma/package.json
@@ -10,8 +10,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/spatial/package.json
+++ b/modules/demo/spatial/package.json
@@ -10,8 +10,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/tfjs/addition-rnn/package.json
+++ b/modules/demo/tfjs/addition-rnn/package.json
@@ -10,8 +10,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/tfjs/webgl-tests/package.json
+++ b/modules/demo/tfjs/webgl-tests/package.json
@@ -10,8 +10,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@babel/core": "7.14.6",

--- a/modules/demo/xterm/package.json
+++ b/modules/demo/xterm/package.json
@@ -10,8 +10,8 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "watch": "find -type f | entr -c -d -r node index.js"
+    "start": "node -r esm index.js",
+    "watch": "find -type f | entr -c -d -r node -r esm index.js"
   },
   "dependencies": {
     "@nvidia/glfw": "0.0.1",

--- a/modules/glfw/package.json
+++ b/modules/glfw/package.json
@@ -41,7 +41,6 @@
     "jsdom": "16.6.0",
     "lasso-resolve-from": "1.2.0",
     "message-port-polyfill": "0.2.0",
-    "mjolnir.js": "2.5.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "rxjs": "6.6.7",

--- a/modules/glfw/src/jsdom/globals.ts
+++ b/modules/glfw/src/jsdom/globals.ts
@@ -14,6 +14,7 @@
 
 import * as gl from '@nvidia/webgl';
 import * as jsdom from 'jsdom';
+import * as Path from 'path';
 import {parse as parseURL} from 'url';
 
 import {installObjectURL} from './object-url';
@@ -199,13 +200,15 @@ Object.defineProperties(window.SVGElement.prototype, {
 
 try {
   const hammerjs = require('hammerjs');
-  for (const x of ['es5', 'es6', 'esm']) {
+  for (const x of ['src', 'dist/es5', 'dist/es6', 'dist/esm']) {
     try {
-      const b = 'mjolnir.js/dist/' + x;
-      const o = require(b + '/utils/hammer-overrides');
-      o.enhancePointerEventInput(hammerjs.PointerEventInput);
-      o.enhanceMouseInput(hammerjs.MouseInput);
-      const mjolnirHammer   = require(b + '/utils/hammer');
+      const b                                             = Path.join('mjolnir.js', x);
+      const utilsHammer                                   = Path.join(b, 'utils/hammer');
+      const utilsHammerOverrides                          = `${utilsHammer}-overrides`;
+      const {enhancePointerEventInput, enhanceMouseInput} = require(utilsHammerOverrides);
+      enhancePointerEventInput(hammerjs.PointerEventInput);
+      enhanceMouseInput(hammerjs.MouseInput);
+      const mjolnirHammer   = require(utilsHammer);
       mjolnirHammer.Manager = hammerjs.Manager;
       mjolnirHammer.default = hammerjs;
     } catch (e) { /**/

--- a/scripts/demo/linux.sh
+++ b/scripts/demo/linux.sh
@@ -58,5 +58,5 @@ fi
 if [[ "$DEMO" =~ "modules/demo/client-server" ]]; then
     NODE_ENV=production exec npm --prefix="$DEMO" $ARGS start
 else
-    NODE_ENV=production exec node --trace-uncaught "$DEMO" $ARGS
+    NODE_ENV=production exec node --trace-uncaught -r esm "$DEMO" $ARGS
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,7 +21,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz#7b047d7a3a89a67d2258dc61f604f098f1bc7e08"
   integrity sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==
 
-"@babel/core@7.14.6", "@babel/core@^7.1.0", "@babel/core@^7.7.5":
+"@babel/core@7.14.6":
   version "7.14.6"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
   integrity sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==
@@ -42,12 +42,33 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz#848d7b9f031caca9d0cd0af01b063f226f52d785"
-  integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
+"@babel/core@^7.1.0", "@babel/core@^7.7.5":
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.14.8.tgz#20cdf7c84b5d86d83fac8710a8bc605a7ba3f010"
+  integrity sha512-/AtaeEhT6ErpDhInbXmjHcUQXH0L0TEgscfcxk1qbOvLuKCa5aZT0SOOtDKFY96/CLROwbLSKyFor6idgNaU4Q==
   dependencies:
-    "@babel/types" "^7.14.5"
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.14.8"
+    "@babel/helper-compilation-targets" "^7.14.5"
+    "@babel/helper-module-transforms" "^7.14.8"
+    "@babel/helpers" "^7.14.8"
+    "@babel/parser" "^7.14.8"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.8"
+    "@babel/types" "^7.14.8"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.14.5", "@babel/generator@^7.14.8":
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz#bf86fd6af96cf3b74395a8ca409515f89423e070"
+  integrity sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==
+  dependencies:
+    "@babel/types" "^7.14.8"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -77,13 +98,13 @@
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.14.5":
-  version "7.14.6"
-  resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz#f114469b6c06f8b5c59c6c4e74621f5085362542"
-  integrity sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.8.tgz#a6f8c3de208b1e5629424a9a63567f56501955fc"
+  integrity sha512-bpYvH8zJBWzeqi1o+co8qOrw+EXzQ/0c74gVmY205AWXy9nifHrOg77y+1zwxX5lXE7Icq4sPlSQ4O2kWBrteQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.14.5"
     "@babel/helper-function-name" "^7.14.5"
-    "@babel/helper-member-expression-to-functions" "^7.14.5"
+    "@babel/helper-member-expression-to-functions" "^7.14.7"
     "@babel/helper-optimise-call-expression" "^7.14.5"
     "@babel/helper-replace-supers" "^7.14.5"
     "@babel/helper-split-export-declaration" "^7.14.5"
@@ -140,7 +161,7 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-member-expression-to-functions@^7.14.5":
+"@babel/helper-member-expression-to-functions@^7.14.5", "@babel/helper-member-expression-to-functions@^7.14.7":
   version "7.14.7"
   resolved "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz#97e56244beb94211fe277bd818e3a329c66f7970"
   integrity sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==
@@ -154,19 +175,19 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-module-transforms@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz#7de42f10d789b423eb902ebd24031ca77cb1e10e"
-  integrity sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==
+"@babel/helper-module-transforms@^7.14.5", "@babel/helper-module-transforms@^7.14.8":
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.8.tgz#d4279f7e3fd5f4d5d342d833af36d4dd87d7dc49"
+  integrity sha512-RyE+NFOjXn5A9YU1dkpeBaduagTlZ0+fccnIcAGbv1KGUlReBj7utF7oEth8IdIBQPcux0DDgW5MFBH2xu9KcA==
   dependencies:
     "@babel/helper-module-imports" "^7.14.5"
     "@babel/helper-replace-supers" "^7.14.5"
-    "@babel/helper-simple-access" "^7.14.5"
+    "@babel/helper-simple-access" "^7.14.8"
     "@babel/helper-split-export-declaration" "^7.14.5"
-    "@babel/helper-validator-identifier" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.14.8"
     "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
+    "@babel/traverse" "^7.14.8"
+    "@babel/types" "^7.14.8"
 
 "@babel/helper-optimise-call-expression@^7.14.5":
   version "7.14.5"
@@ -199,12 +220,12 @@
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/helper-simple-access@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz#66ea85cf53ba0b4e588ba77fc813f53abcaa41c4"
-  integrity sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==
+"@babel/helper-simple-access@^7.14.5", "@babel/helper-simple-access@^7.14.8":
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz#82e1fec0644a7e775c74d305f212c39f8fe73924"
+  integrity sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==
   dependencies:
-    "@babel/types" "^7.14.5"
+    "@babel/types" "^7.14.8"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.14.5":
   version "7.14.5"
@@ -220,10 +241,10 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-validator-identifier@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
-  integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
+"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.8":
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz#32be33a756f29e278a0d644fa08a2c9e0f88a34c"
+  integrity sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==
 
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
@@ -240,14 +261,14 @@
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/helpers@^7.14.6":
-  version "7.14.6"
-  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz#5b58306b95f1b47e2a0199434fa8658fa6c21635"
-  integrity sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==
+"@babel/helpers@^7.14.6", "@babel/helpers@^7.14.8":
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz#839f88f463025886cff7f85a35297007e2da1b77"
+  integrity sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==
   dependencies:
     "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
+    "@babel/traverse" "^7.14.8"
+    "@babel/types" "^7.14.8"
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.14.5":
   version "7.14.5"
@@ -258,10 +279,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7":
-  version "7.14.7"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
-  integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.14.8":
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz#66fd41666b2d7b840bd5ace7f7416d5ac60208d4"
+  integrity sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.14.5":
   version "7.14.5"
@@ -929,9 +950,9 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
-  version "7.14.6"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
-  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
+  integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -944,18 +965,18 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5":
-  version "7.14.7"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz#64007c9774cfdc3abd23b0780bc18a3ce3631753"
-  integrity sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.14.8":
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.8.tgz#c0253f02677c5de1a8ff9df6b0aacbec7da1a8ce"
+  integrity sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==
   dependencies:
     "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.14.5"
+    "@babel/generator" "^7.14.8"
     "@babel/helper-function-name" "^7.14.5"
     "@babel/helper-hoist-variables" "^7.14.5"
     "@babel/helper-split-export-declaration" "^7.14.5"
-    "@babel/parser" "^7.14.7"
-    "@babel/types" "^7.14.5"
+    "@babel/parser" "^7.14.8"
+    "@babel/types" "^7.14.8"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -968,12 +989,12 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
-  version "7.14.5"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
-  integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
+"@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.14.8", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+  version "7.14.8"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz#38109de8fcadc06415fbd9b74df0065d4d41c728"
+  integrity sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.14.8"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1124,9 +1145,9 @@
   integrity sha512-nnjfwQ4jOFcfe3JMCKcGCKlhkRw+wVdRdFguc0vndzjpPFJ596hTk9L0Z4UklxxKtmP5tv6r/xoFX5BQVP6rJg==
 
 "@eslint/eslintrc@^0.4.1":
-  version "0.4.2"
-  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz#f63d0ef06f5c0c57d76c4ab5f63d3835c51b0179"
-  integrity sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
+  integrity sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -2701,9 +2722,9 @@
     "@lumino/algorithm" "^1.6.0"
 
 "@lumino/widgets@^1.3.0":
-  version "1.23.0"
-  resolved "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.23.0.tgz#096c7574de75fa67b32bcb914c5dae290fbee6f3"
-  integrity sha512-0Akt9ESgc06SJ3EJG3VK1Liw+AAjRWkKMfm8VUTwT/1QJYYGZ8kfHNO97mkBLv+0EkLEkZIeaQb8fIoU6vh7bw==
+  version "1.24.0"
+  resolved "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.24.0.tgz#9e978052e427ae18f11f27eb2388deaaf359bc93"
+  integrity sha512-ZMX957npESqtxPdLfzh/rpMdz0QYZ+Vbdv7mMFAd0Qfy+pYJjqB++WQ36yUfvV2ZOa2ETJSjw2x7QEFEO5hXzA==
   dependencies:
     "@lumino/algorithm" "^1.6.0"
     "@lumino/commands" "^1.15.0"
@@ -2787,7 +2808,7 @@
   resolved "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@math.gl/core@3.4.3", "@math.gl/core@^3.3.0", "@math.gl/core@^3.4.1", "@math.gl/core@^3.4.2":
+"@math.gl/core@3.4.3":
   version "3.4.3"
   resolved "https://registry.npmjs.org/@math.gl/core/-/core-3.4.3.tgz#a0e9449b680ddeb689a2e5c8be58899143175915"
   integrity sha512-gWAuVkNi8cS4+ejZnhkMjTcKHFSYUSCTSXyCY3ReLIOknyy1QEucecOCyl3xpubRwCzPgCOiQ0yFvEdIFPpH6Q==
@@ -2795,45 +2816,53 @@
     "@babel/runtime" "^7.12.0"
     gl-matrix "^3.0.0"
 
-"@math.gl/culling@^3.3.0", "@math.gl/culling@^3.4.2":
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/@math.gl/culling/-/culling-3.4.3.tgz#e85141ccdf5d34a2618728e0b1c8b0cdd45dd777"
-  integrity sha512-110pCxuzu3IUMaYFeiKVvVB/NMMkNXTph2x8U5FFOUgyDbLqKKH/l1ZRoK9JyZ5qbYJZzYr6v++bxcnc5uHOIg==
+"@math.gl/core@3.5.3", "@math.gl/core@^3.3.0", "@math.gl/core@^3.4.1", "@math.gl/core@^3.4.2":
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@math.gl/core/-/core-3.5.3.tgz#8f40c374c68cf2731f7e2c2b7609094b10ff767a"
+  integrity sha512-TaSnvG0qFh1VxeNW5L58jSx0nJUMWMpUl6zo6Z3ScQzFySG5cicGOBzk/D40RkIZWPazCKCZ+ZThg5npSK9y3g==
   dependencies:
     "@babel/runtime" "^7.12.0"
-    "@math.gl/core" "3.4.3"
+    gl-matrix "^3.0.0"
+
+"@math.gl/culling@^3.3.0", "@math.gl/culling@^3.4.2":
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@math.gl/culling/-/culling-3.5.3.tgz#5b87646b42b76d1bba1a8f41e0d65447944a43fd"
+  integrity sha512-ABpAcrvoIOLSm1EUkwgDem4RfO28HWPBs/+taZ/ZSpJG6KiVPklpKU1NCK+05HuJStkpFZ+XlWtehWU6FAMCyA==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@math.gl/core" "3.5.3"
     gl-matrix "^3.0.0"
 
 "@math.gl/geospatial@^3.3.0":
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.4.3.tgz#47c611e1c9249aaa91e93227d37ae9d7aeb1c6fb"
-  integrity sha512-5IG85T0WkjxQD8xumcxQypWCw6OscvCAh7IH7E3G6P6r5et2UYUPXFtjXI1ZIdUS/SjD3Jd9Sr4ZKeVSAigt6w==
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.5.3.tgz#90a39fea16bca6c32a471cd89699c3831fb347e7"
+  integrity sha512-cnc8VMQrt30JmlG200VDJmmvSjaGW57gY9KEZ+raapxyyFyfDNuAuIrIxe+zbK66FbvFWTbJlDaNmKqVG+ohyw==
   dependencies:
     "@babel/runtime" "^7.12.0"
-    "@math.gl/core" "3.4.3"
+    "@math.gl/core" "3.5.3"
     gl-matrix "^3.0.0"
 
 "@math.gl/polygon@^3.4.2":
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.4.3.tgz#1c54a4cad2df8db41a980c03c1833fb5fc241e09"
-  integrity sha512-ZhccVGn0PgwsN/SNT1jlPPOydkY8bW0YDDWOK4eH70zypLVYSorAyxWEwefqBjZxCkgbQU3WnpxHNSMLr+jVCQ==
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.5.3.tgz#5cdd6ad623e3a9652ed25eb52bb9941c657ee78d"
+  integrity sha512-VktscmyQg/Rd56nJk0Nj/UyvnPDbsnZNMWCdl3G5AYenYzLWy6h4FEWhLx8pD+Xw7VuFot8LR4WAK2TPzXzrWw==
   dependencies:
-    "@math.gl/core" "3.4.3"
+    "@math.gl/core" "3.5.3"
 
 "@math.gl/proj4@^3.3.0":
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/@math.gl/proj4/-/proj4-3.4.3.tgz#6a82119b6c199097c3a8d80d70a3c6bc7ef27dbe"
-  integrity sha512-oVKVWfn8GUshlSQoU+15U1io7NNjfe5m5F+HRrWEjsdWhcY/gGzhw7wa1oSbwcbgmzHTeHwxyt0VeJh3EZa7JA==
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@math.gl/proj4/-/proj4-3.5.3.tgz#916adec508901a77d2113cb92e51d4a84c8c98f3"
+  integrity sha512-gFMsePbd1vs+ovjAGrIW0VGPh0Kmj3wueh6sZhD0jKS1zm5VfWsn8aNrPsjdHQJK68/XMg/XEKy+kJM9nqo1hg==
   dependencies:
     "@babel/runtime" "^7.12.0"
-    "@math.gl/core" "3.4.3"
+    "@math.gl/core" "3.5.3"
     "@types/proj4" "^2.5.0"
-    proj4 "^2.6.2"
+    proj4 "2.6.2"
 
 "@math.gl/web-mercator@^3.3.0", "@math.gl/web-mercator@^3.4.2", "@math.gl/web-mercator@^3.4.3":
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.4.3.tgz#6bcb262a92453399229b173bc9a825ebd3356f38"
-  integrity sha512-wfT1ku2b0k9MmaesFev60PXCCqqDvCR9batcY99ob/nMRXcQ/F5yVChS07OIqjUJseK6+6Gep9iYXiflPyPR2Q==
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.5.3.tgz#4cc7ba98a48580a18ad683206a6f6002fa9d2d7e"
+  integrity sha512-WZE9ALeTS4n3HDgkqTxcNLBU7DL0mjmPXSrcqSZIUeDY00+LCtNvMQWUAwqolpB7nD71vD6HLW8delzVuy4teA==
   dependencies:
     "@babel/runtime" "^7.12.0"
     gl-matrix "^3.0.0"
@@ -2920,10 +2949,10 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz#8bc912edae8c03e002882cf1e29b595b7da9b441"
-  integrity sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ==
+"@octokit/openapi-types@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.1.0.tgz#7f73adbde8ba2d2512de90ea8a5da68b25d65d0a"
+  integrity sha512-XBP03pG4XuTU+VgeJM1ozRdmZJerMG4tk6wA+raFKycC4qV9jtD2UQroAg9bAcmI3Q0zWvifeDGtPqsFjMzkLg==
 
 "@octokit/plugin-enterprise-rest@^6.0.1":
   version "6.0.1"
@@ -3010,11 +3039,11 @@
     "@types/node" ">= 8"
 
 "@octokit/types@^6.0.3", "@octokit/types@^6.16.1":
-  version "6.19.0"
-  resolved "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz#e2b6fedb10c8b53cf4574aa5d1a8a5611295297a"
-  integrity sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/@octokit/types/-/types-6.21.0.tgz#723d0296d35296d6ec91247e770f24e6cd51d4ee"
+  integrity sha512-VPSxn9uhCoOUMpxCsOAQhf8DgIx+uzFjZRYDiZS5+TvrKaEwBrWkjr/5NmUVvPbW6xdPC2n3yL3XCnoxa4rxvg==
   dependencies:
-    "@octokit/openapi-types" "^8.3.0"
+    "@octokit/openapi-types" "^9.1.0"
 
 "@opentelemetry/api@0.14.0":
   version "0.14.0"
@@ -3033,10 +3062,10 @@
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@probe.gl/stats@3.3.1", "@probe.gl/stats@^3.3.0":
-  version "3.3.1"
-  resolved "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.3.1.tgz#6119c4ce978420ea08464aaf1773d983d4ad9c66"
-  integrity sha512-7ekl4qYndDgmCzZMNhicgJpIzApyjdqo67qv1zKx8hmAgC+AeCk6LE8sdiTauddd8+FDViAkxhrr271KwOgHfw==
+"@probe.gl/stats@3.4.0", "@probe.gl/stats@^3.3.0":
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.4.0.tgz#9315c4726ea031661daa6a1771b8e978684a8b9b"
+  integrity sha512-Gl37r9qGuiKadIvTZdSZvzCNOttJYw6RcY1oT0oDuB8r2uhuZAdSMQRQTy9FTinp6MY6O9wngGnV6EpQ8wSBAw==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
@@ -3158,9 +3187,9 @@
   integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
 
 "@tsconfig/node16@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz#a6ca6a9a0ff366af433f42f5f0e124794ff6b8f1"
-  integrity sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/arcgis-js-api@4.10.0":
   version "4.10.0"
@@ -3334,9 +3363,9 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@>= 8":
-  version "16.3.2"
-  resolved "https://registry.npmjs.org/@types/node/-/node-16.3.2.tgz#655432817f83b51ac869c2d51dd8305fb8342e16"
-  integrity sha512-jJs9ErFLP403I+hMLGnqDRWT0RYKSvArxuBVh2veudHV7ifEC1WAmjJADacZ7mRbA2nWgHtn8xyECMAot0SkAw==
+  version "16.4.0"
+  resolved "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz#2c219eaa3b8d1e4d04f4dd6e40bc68c7467d5272"
+  integrity sha512-HrJuE7Mlqcjj+00JqMWpZ3tY8w7EUd+S0U3L1+PQSWiXZbOgyQDvi+ogoUxaHApPJq5diKxYBQwA3iIlNcPqOg==
 
 "@types/node@^13.7.4":
   version "13.13.52"
@@ -3638,9 +3667,9 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.6.1"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz#ae65764bf1edde8cd861281cda5057852364a295"
-  integrity sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==
+  version "8.6.2"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz#2fb45e0e5fcbc0813326c1c3da535d1881bb0571"
+  integrity sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -4559,9 +4588,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228:
-  version "1.0.30001245"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz#45b941bbd833cb0fa53861ff2bae746b3c6ca5d4"
-  integrity sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==
+  version "1.0.30001246"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001246.tgz#fe17d9919f87124d6bb416ef7b325356d69dc76c"
+  integrity sha512-Tc+ff0Co/nFNbLOrziBXmMVtpt9S2c2Y+Z9Nk9Khj09J+0zR9ejvIW5qkZAErCbOrVODCx/MN+GpB5FNBs5GFA==
 
 canvas@2.8.0:
   version "2.8.0"
@@ -5352,9 +5381,9 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     randomfill "^1.0.3"
 
 "crypto-js@^3.0.0 || ^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
-  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 css-in-js-utils@^2.0.0:
   version "2.0.1"
@@ -6178,9 +6207,9 @@ echarts@5.0.2:
     zrender "5.0.4"
 
 electron-to-chromium@^1.3.723:
-  version "1.3.776"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.776.tgz#33f6e2423b61f1bdaa8d2a103aae78a09764a75f"
-  integrity sha512-V0w7eFSBoFPpdw4xexjVPZ770UDZIevSwkkj4W97XbE3IsCsTRFpa7/yXGZ88EOQAUEA09JMMsWK0xsw0kRAYw==
+  version "1.3.784"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.784.tgz#c370be79374b02b7f13e8a8fb0d7a02641161dac"
+  integrity sha512-JTPxdUibkefeomWNaYs8lI/x/Zb4cOhZWX+d7kpzsNKzUd07pNuo/AcHeNJ/qgEchxM1IAxda9aaGUhKN/poOg==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -6419,6 +6448,11 @@ eslint@7.27.0:
     table "^6.0.9"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
+
+esm@3.2.25:
+  version "3.2.25"
+  resolved "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
@@ -7098,12 +7132,12 @@ get-package-type@^0.1.0:
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
 get-pixels@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.npmjs.org/get-pixels/-/get-pixels-3.3.2.tgz#3f62fb8811932c69f262bba07cba72b692b4ff03"
-  integrity sha512-6ar+8yPxRd1pskEcl2GSEu1La0+xYRjjnkby6AYiRDDwZ0tJbPQmHnSeH9fGLskT8kvR0OukVgtZLcsENF9YKQ==
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/get-pixels/-/get-pixels-3.3.3.tgz#71e2dfd4befb810b5478a61c6354800976ce01c7"
+  integrity sha512-5kyGBn90i9tSMUVHTqkgCHsoWoR+/lGbl4yC83Gefyr0HLIhgSWEx/2F/3YgsZ7UpYNuM6pDhDK7zebrUJ5nXg==
   dependencies:
     data-uri-to-buffer "0.0.3"
-    jpeg-js "^0.3.2"
+    jpeg-js "^0.4.1"
     mime-types "^2.0.1"
     ndarray "^1.0.13"
     ndarray-pack "^1.1.1"
@@ -8364,13 +8398,13 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-ix@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/ix/-/ix-4.4.0.tgz#4c1a4ad7eddd97a79bdd2a49c843ed327ff0e75e"
-  integrity sha512-DQRUn7mIklKSRS1TOG2jpcnybRXqDluCbllRyUbEImH080pyknxdJbI8WzRNJD9m7OuiePj099GASD551J4NEA==
+ix@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.npmjs.org/ix/-/ix-4.4.1.tgz#8ec5f4f420c504a9906ffc2e2234f50147b9488a"
+  integrity sha512-Jsl7cUf7CA1MkznzAuVy4K6V1Zsfx+EAh0ZgiGhGAADaEGKiMV+sJx8Qe4hx0CsyI475Yt3ppoRS8M8oOueqlA==
   dependencies:
     "@types/node" "^13.7.4"
-    tslib "2.0.0"
+    tslib "^2.3.0"
 
 jasmine-core@3.1.0, jasmine-core@~3.1.0:
   version "3.1.0"
@@ -8778,15 +8812,15 @@ jest@26.5.3:
     import-local "^3.0.2"
     jest-cli "^26.5.3"
 
-jpeg-js@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.0.4.tgz#06aaf47efec7af0b1924a59cd695a6d2b5ed870e"
-  integrity sha1-Bqr0fv7HrwsZJKWc1pWm0rXthw4=
-
 jpeg-js@^0.3.2:
   version "0.3.7"
   resolved "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz#471a89d06011640592d314158608690172b1028d"
   integrity sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==
+
+jpeg-js@^0.4.1:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
+  integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
 
 jquery@^3.1.1:
   version "3.6.0"
@@ -9495,12 +9529,19 @@ marked@^2.1.1:
   resolved "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
   integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
 
-math.gl@3.4.3, math.gl@^3.4.2:
+math.gl@3.4.3:
   version "3.4.3"
   resolved "https://registry.npmjs.org/math.gl/-/math.gl-3.4.3.tgz#8e73db7900dec6a5eb0c2c54af7429793b95e7b8"
   integrity sha512-GSX4GQUVbEQtFnQryDIJVx35WO4HP55NbnIP18/a9G7e5jbTj7QqR2pHKkdlvP5D3jDHP09o39cXMcx0YxqUSA==
   dependencies:
     "@math.gl/core" "3.4.3"
+
+math.gl@^3.4.2:
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/math.gl/-/math.gl-3.5.3.tgz#aeb6745ece33bb9207c74d866ab6a265a74ddd06"
+  integrity sha512-cRQRZlc+XvNHd3bIfu3kdPPPAW0vwDelZJmkjn2TDvCyPcmyDtAiZ2Poo1aFoINP7HzN6oHYxapc/0wV3q6Opg==
+  dependencies:
+    "@math.gl/core" "3.5.3"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -9760,14 +9801,6 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
-
-mjolnir.js@2.5.2:
-  version "2.5.2"
-  resolved "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.5.2.tgz#f0c71023ec662ec7cb14561bdc189ebf24d085ed"
-  integrity sha512-mn20ZhxsWqs41HZS7I2ha0h+FipNSwwuHXeo885YIhj3+4GhIWIBozKLObwR9cnX7sTyIxDQMQiyEUneuCFNkg==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    hammerjs "^2.0.8"
 
 mjolnir.js@^2.5.0:
   version "2.6.0"
@@ -10967,12 +11000,12 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     react-is "^17.0.1"
 
 probe.gl@^3.2.1, probe.gl@^3.3.0:
-  version "3.3.1"
-  resolved "https://registry.npmjs.org/probe.gl/-/probe.gl-3.3.1.tgz#4d60d0e896aa7eee6a6b1bfe4d59120f7d247f7a"
-  integrity sha512-RI6gxvEyTEdRMzT1np8HvbBOFNYQ0HwE3kZvK790tg/ldwFy7Qvs7cllz4MDT84QG2IMDUu7EsTXQX3qtzdx3w==
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/probe.gl/-/probe.gl-3.4.0.tgz#f35029b0041fb909caff493ab23feae53339261e"
+  integrity sha512-9CLByZATuhuG/Viq3ckfWU+dAhb7dMmjzsyCy4s7ds9ueTejcVRENxL197/XacOK/AN61YrEERB0QnouB0Qc0Q==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@probe.gl/stats" "3.3.1"
+    "@probe.gl/stats" "3.4.0"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -10994,13 +11027,13 @@ progress@^2.0.0, progress@^2.0.1, progress@^2.0.3:
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-proj4@^2.6.2:
-  version "2.7.4"
-  resolved "https://registry.npmjs.org/proj4/-/proj4-2.7.4.tgz#1b53547dbe1f21f0a418396e9dd84e473d66d92a"
-  integrity sha512-WAY3Rk/PeFrR/Pf2gryrEPFgfo83C4U1ixS8bBr05fJ88z+QsTDR0tzg6k3Q7TBrJUhwB03NMPVT3aVkv9mZ6Q==
+proj4@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/proj4/-/proj4-2.6.2.tgz#4665d7cbc30fd356375007c2fed53b07dbda1d67"
+  integrity sha512-Pn0+HZtXb4JzuN8RR0VM7yyseegiYHbXkF+2FOdGpzRojcZ1BTjWxOh7qfp2vH0EyLu8pvcrhLxidwzgyUy/Gw==
   dependencies:
     mgrs "1.0.0"
-    wkt-parser "^1.3.1"
+    wkt-parser "^1.2.4"
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -12053,13 +12086,13 @@ sane@^4.0.3:
     walker "~1.0.5"
 
 save-pixels@^2.3.2:
-  version "2.3.4"
-  resolved "https://registry.npmjs.org/save-pixels/-/save-pixels-2.3.4.tgz#49d349c06b8d7c0127dbf0da24b44aca5afb59fe"
-  integrity sha1-SdNJwGuNfAEn2/DaJLRKylr7Wf4=
+  version "2.3.5"
+  resolved "https://registry.npmjs.org/save-pixels/-/save-pixels-2.3.5.tgz#5f2fb7f845a3a27fd230d66bc4abce19c8b076a5"
+  integrity sha512-KJrlGCp1+fT9UD0Bux3MyFVQ54ieB+5+By/8u971BS2IQuiUctcKYMghudu/yAJebhqMK3B/Epi9vqy8QVNIUA==
   dependencies:
     contentstream "^1.0.0"
     gif-encoder "~0.4.1"
-    jpeg-js "0.0.4"
+    jpeg-js "^0.3.2"
     ndarray "^1.0.18"
     ndarray-ops "^1.2.2"
     pngjs-nozlib "^1.0.0"
@@ -13283,11 +13316,6 @@ ts-pnp@^1.1.6:
   resolved "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-tslib@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
-  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
-
 tslib@2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
@@ -13434,9 +13462,9 @@ typical@^5.2.0:
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 uglify-js@^3.1.4:
-  version "3.13.10"
-  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz#a6bd0d28d38f592c3adb6b180ea6e07e1e540a8d"
-  integrity sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==
+  version "3.14.0"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.0.tgz#2d723a0afee81e0d08db9354a9c277006e942386"
+  integrity sha512-R/tiGB1ZXp2BC+TkRGLwj8xUZgdfT2f4UZEgX6aVjJ5uttPrr4fYmwTWDGqVnBCLbOXRMY6nr/BTbwCtVfps0g==
 
 uid-number@0.0.6:
   version "0.0.6"
@@ -13818,9 +13846,9 @@ web-streams-polyfill@2.1.1:
   integrity sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg==
 
 web-streams-polyfill@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz#f49e487eedeca47a207c1aee41ee5578f884b42f"
-  integrity sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA==
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.0.tgz#86f983b4f44745502b0d8563d9ef3afc609d4465"
+  integrity sha512-wO9r1YnYe7kFBLHyyVEhV1H8VRWoNiNnuP+v/HUUmSTaRF8F93Kmd3JMrETx0f11GXxRek6OcL2QtjFIdc5WYw==
 
 webgl-debug@^2.0.1:
   version "2.0.1"
@@ -13944,7 +13972,7 @@ winreg@~1.2.2:
   resolved "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz#ba065629b7a925130e15779108cf540990e98d1b"
   integrity sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs=
 
-wkt-parser@^1.3.1:
+wkt-parser@^1.2.4:
   version "1.3.1"
   resolved "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.1.tgz#a569678eb28f82f6739f736319be073e32bf8191"
   integrity sha512-XK5qV+Y5gsygQfHx2/cS5a7Zxsgleaw8iX5UPC5eOXPc0TgJAu1JB9lr0iYYX3zAnN3p0aNiaN5c+1Bdblxwrg==


### PR DESCRIPTION
A new version of `mjolnir.js` was released that broke our workarounds. This change runs our demos with `esm` again so we can reliably patch mjolnir.js to work in `jsdom`.